### PR TITLE
Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ Available playbooks are:
 - `slurm-db.yml`: The basic slurm cluster plus slurmdbd backed by mariadb on the login/control node, which provides more detailed accounting.
 - `monitoring-simple.yml`: Add basic monitoring, with prometheus and grafana on the login/control node providing graphical dashboards (over http) showing cpu/network/memory/etc usage for each cluster node. Run `slurm-simple.yml` first.
 - `monitoring-db.yml`: Basic monitoring plus statistics and dashboards for Slurm jobs . Run `slurm-db.yml` first.
-- `stats.yml`: Extend monitoring to include statistics and dashboards for Slurm jobs. Run `slurm-db.yml` and `monitoring.yml` first.
 - `rebuild.yml`: Deploy scripts to enable the reimaging compute nodes controlled by Slurm's `scontrol` command.
 - `config-drive.yml` and `main.pkr.hcl`: Packer-based build of compute note images - see separate section below.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-A simple test/demo case for StackHPC's `openhpc` role using VMs on `alaska`.
+# Demos for OpenHPC on OpenStack
+
+This repo contains ansible playbooks to demonstrate the `stackhpc.openhpc` role and functionality from `stackhpc.slurm_openstack_tools` collection.
+
+All demos use a terraform-deployed cluster with a single control/login node and two compute nodes.
 
 # Installation
 
@@ -9,24 +13,39 @@ A simple test/demo case for StackHPC's `openhpc` role using VMs on `alaska`.
     pip install -U pip
     pip install -U setuptools
     pip install -r requirements.txt
-    ansible-galaxy install -r requirements.yml -p roles
+    ansible-galaxy install -r requirements.yml -p roles # FIXME - needs git nfs role too currently
     cd roles
-    git clone git@github.com:stackhpc/ansible-role-openhpc.git # for development
+    git clone git@github.com:stackhpc/ansible-role-openhpc.git # FIXME
     cd ..
     yum install terraform
     terraform init
+
+# Deploy nodes with Terraform
+
+- Modify the keypair in `main.tf` and ensure the required Centos images are available on OpenStack.
+- Activate the virtualenv and create the instances:
+
+      . venv/bin/activate
+      terraform apply
+
+This creates an ansible inventory file `./inventory`.
+
+Note that this terraform deploys instances onto an existing network - for production use you probably want to create a network for the cluster.
+
+# Create and configure cluster with Ansible
+
+|Playbook | Previous plays required	| Notes |
+|-------- |	----------------------- | ----- |
+| slurm-simple.yml	| |
+| slurm-db.yml | |
+| monitoring.yml | slurm-simple.yml or slurm-db.yml	| Needs Wills changes for slurm-stats merged |
+| slurm-stats.yml |	monitoring.yml | Rename slurm-stats to just "stats"? |
+| rebuild.yml |	slurm-simple.yml or slurm-db.yml | |
+| config-drive.yml | slurm-simple.yml or slurm-db.yml | |
+| main.pkr.hcl*	|config-drive.yml | |
+
     
-# Usage
 
-Modify the keypair in `main.tf`.
-
-Activate the virtualenv:
-
-    . venv/bin/activate
-
-Create the instances (on an existing network):
-
-    terraform apply --auto-approve
 
 Configure a slurm cluster:
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Available playbooks are:
 
 - `slurm-simple.yml`: A basic slurm cluster.
 - `slurm-db.yml`: The basic slurm cluster plus slurmdbd backed by mariadb on the login/control node, which provides more detailed accounting.
-- `monitoring.yml`: Add basic monitoring, with prometheus and grafana on the login/control node providing graphical dashboards (over http) showing cpu/network/memory/etc usage for each cluster node. Run either `slurm-simple.yml` or `slurm-db.yml` first.
+- `monitoring-simple.yml`: Add basic monitoring, with prometheus and grafana on the login/control node providing graphical dashboards (over http) showing cpu/network/memory/etc usage for each cluster node. Run `slurm-simple.yml` first.
+- `monitoring-db.yml`: Basic monitoring plus statistics and dashboards for Slurm jobs . Run `slurm-db.yml` first.
 - `stats.yml`: Extend monitoring to include statistics and dashboards for Slurm jobs. Run `slurm-db.yml` and `monitoring.yml` first.
 - `rebuild.yml`: Deploy scripts to enable the reimaging compute nodes controlled by Slurm's `scontrol` command.
 - `config-drive.yml` and `main.pkr.hcl`: Packer-based build of compute note images - see separate section below.


### PR DESCRIPTION
Update README to try to show the dependencies between plays.

NB: this assumes that:
- inventories are merged so that only the basic inventory (no additional groups) is used
- Changes needed for stats play are merged into monitoring.yml
- slurm-stats.yml is renamed to stats.yml, i.e. so that `slurm-` prefixed ones are the actual cluster setup