### PR TITLE
use login hostname for nfs mount as well as slurmctld name

### DIFF
--- a/slurm-simple.yml
+++ b/slurm-simple.yml
@@ -7,7 +7,7 @@
         nfs_enable:
           server:  "{{ inventory_hostname in groups['cluster_login'] | first }}"
           clients: "{{ inventory_hostname in groups['cluster_compute'] }}"
-        nfs_server: "{{ hostvars[groups['cluster_login'] | first ]['server_networks']['ilab'][0] }}"
+        nfs_server: "{{ groups['cluster_login'] | first }}"
         nfs_export: "/mnt/nfs/"
         nfs_client_mnt_point: "/mnt/nfs/"
     


### PR DESCRIPTION
Playbooks already assume working DNS (hence no /etc/hosts creation) - this is required for image build.
Therefore the specification of the slurmctld address was already just by hostname.
PR changes NFS mount to be the same.

Will help for improving image build code.