### PR TITLE
Fix nfs when control===login

### DIFF
--- a/environments/common/inventory/group_vars/all/nfs.yml
+++ b/environments/common/inventory/group_vars/all/nfs.yml
@@ -5,7 +5,10 @@ nfs_server_default: "{{ hostvars[groups['control'] | first ].internal_address }}
 nfs_configuration:
   nfs_enable:
       server:  "{{ inventory_hostname in groups['control'] }}"
-      clients: "{{ inventory_hostname in groups['compute'] or inventory_hostname in groups['login']  }}"
+      # Don't mount share on same server as client...
+      # Could do something like nfs_clients: '"nfs_servers" not in group_names' instead.
+      # See also constructed inventory: https://docs.ansible.com/ansible/devel/collections/ansible/builtin/constructed_inventory.html
+      clients: "{{ inventory_hostname in groups['compute'] or (inventory_hostname in groups['login'] and not inventory_hostname in groups['control']) }}"
   nfs_server: "{{ nfs_server_default }}"
   nfs_export: "/mnt/nfs/"
   nfs_client_mnt_point: "/mnt/nfs/"

--- a/environments/common/inventory/group_vars/all/nfs.yml
+++ b/environments/common/inventory/group_vars/all/nfs.yml
@@ -5,10 +5,10 @@ nfs_server_default: "{{ hostvars[groups['control'] | first ].internal_address }}
 nfs_configuration:
   nfs_enable:
       server:  "{{ inventory_hostname in groups['control'] }}"
-      # Don't mount share on same server as client...
+      # Don't mount share on server where it is exported from...
       # Could do something like nfs_clients: '"nfs_servers" not in group_names' instead.
       # See also constructed inventory: https://docs.ansible.com/ansible/devel/collections/ansible/builtin/constructed_inventory.html
-      clients: "{{ inventory_hostname in groups['compute'] or (inventory_hostname in groups['login'] and not inventory_hostname in groups['control']) }}"
+      clients: "{{ inventory_hostname in groups['cluster'] and inventory_hostname not in groups['control'] }}"
   nfs_server: "{{ nfs_server_default }}"
   nfs_export: "/mnt/nfs/"
   nfs_client_mnt_point: "/mnt/nfs/"


### PR DESCRIPTION
The role was trying to mount the share from the same server. Systemd detected
this loop and refused to start the nfs server.

This makes it easier to construct an inventory with a shared control/login node.