### PR TITLE
Add podman children to common/inventory/groups

### DIFF
--- a/environments/common/inventory/groups
+++ b/environments/common/inventory/groups
@@ -13,7 +13,10 @@ login
 control
 compute
 
-[podman]
+[podman:children]
+opendistro
+kibana
+filebeat
 
 [prometheus]
 


### PR DESCRIPTION
As per discussion in #13, so these don't need to be set in concete environments