### PR TITLE
New openhpc_tests group and variables

### DIFF
--- a/ansible/adhoc/test.yml
+++ b/ansible/adhoc/test.yml
@@ -1,17 +1,13 @@
 # NB: this only works on centos 8 / ohpc v2 as we want UCX
 # TODO: add support for groups/partitions
+# TODO: add support for combined login/control nodes?
 # Prequisites:
 # - slurm-libpmi-ohpc package - installed by default by openhpc role
 
-- hosts: cluster
+- hosts: openhpc_tests
   name: Run tests
   tags: test
   gather_facts: true
   tasks:
     - import_role:
         name: stackhpc.slurm_openstack_tools.test
-      vars:
-        openhpc_tests_rootdir: /mnt/nfs/ohcp-tests
-        openhpc_tests_hpl_NB: 192
-        openhpc_tests_nodes: "{{ groups['compute'] | intersect(play_hosts) | join(',') }}"
-        openhpc_slurm_login: "{{ groups['login'][0] }}"

--- a/environments/common/inventory/group_vars/all/openhpc_tests.yml
+++ b/environments/common/inventory/group_vars/all/openhpc_tests.yml
@@ -1,0 +1,3 @@
+openhpc_tests_rootdir: /mnt/nfs/ohcp-tests
+openhpc_tests_hpl_NB: 192
+openhpc_slurm_login: "{{ groups['login'][0] }}"

--- a/environments/common/inventory/groups
+++ b/environments/common/inventory/groups
@@ -41,3 +41,6 @@ filebeat
 [mysql]
 
 [node_exporter]
+
+[openhpc_tests:children]
+cluster


### PR DESCRIPTION
Define an `openhpc_tests` group, defaulting to `cluster`.

This allows e.g. the `openhpc_tests_rootdir` to be easily overriden for clusters not using /mnt/nfs as the shared filesystem.
