### PR TITLE
Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ NB: This section describes generic instructions - check for any environment-spec
 
 ### Overview
 
-An environment defines the configuration for a single instantiation of this Slurm appliance. Each environment is a directory in `environments/', containing:
+An environment defines the configuration for a single instantiation of this Slurm appliance. Each environment is a directory in `environments/`, containing:
 - Any deployment automation required - e.g. Terraform configuration or HEAT templates.
 - An ansible `inventory/` directory.
 - An `activate` script which sets environment variables to point to this configuration.

--- a/README.md
+++ b/README.md
@@ -63,3 +63,25 @@ existing cluster or for initial deployment of a set of compute nodes. Once an en
      ~/.local/bin/packer build --on-error=ask main.pkr.hcl
 
 See `packer/README.md` for more details.
+
+## Environments
+
+An environment is a directory which defines all the configuration for instantiations of this Slurm appliance at one site. A cookiecutter command is described below provided to create a new environment from a template.
+
+Amongst other things, an environments's `activate` script defines the path to a custom `ansible.cfg` which itself defines the paths to inventory directories. Therefore no inventory paths need to be specified to ansible once an environment is activated. All environments include `environments/common/inventory` as the first inventory searched, with the environment-specific inventory then overriding parts of this.
+
+This repository generally follows a convention where:
+- Functionality is defined in terms of ansible roles applied to a a group of the same name, e.g. `openhpc` or `grafana`. The empty groups in the `common` invenvory mean that functionality is disabled by default, and must be enabled for a specific environment by adding hosts or child groups to the group in an environment-specific `environments/<environment>/inventory/groups` file. The meaning of the groups is described below.
+- Environment-specific variables for each role/group can be defined in a group_vars directory of the same name in `environments/<environment>/inventory/group_vars/<group_name>/overrides.yml`. These override any default values specified in `environments/common/inventory/group_vars/all/<group_name>.yml` (the use of `all` here is due to ansible's precedence rules).
+
+### Creating a new environment
+
+TODO: and  mention layout files.
+
+### Modifying an environment
+
+TODO:
+
+### Groups
+
+TODO:

--- a/README.md
+++ b/README.md
@@ -119,15 +119,6 @@ Although most of the inventory uses the group convention described above there a
     See the [openhpc role documentation](https://github.com/stackhpc/ansible-role-openhpc#slurmconf) for more options.
 
 
-# TO MOVE
-
-
-
-    - `control`: A single host for the Slurm control node. Multiple (high availability) control nodes are not supported.
-    - `login`: One or more hosts for Slurm login nodes. Combined control/login nodes are not supported.
-    - `compute`: Hosts for all Slurm compute nodes.
-
-
 ## Adding new functionality
 TODO: this is just rough notes:
 - Add new plays into existing playbook, or add a new playbook and update `site.yml`.

--- a/README.md
+++ b/README.md
@@ -127,37 +127,11 @@ Although most of the inventory uses the group convention described above there a
     - `login`: One or more hosts for Slurm login nodes. Combined control/login nodes are not supported.
     - `compute`: Hosts for all Slurm compute nodes.
 
-## Inventory groups
-
-This repo defines the following groups:
-- `control`: A single Slurm control node. Multiple (high availability) control nodes are not supported.
-- `login`: One Slurm login nodes. Combined control/login nodes are not supported.
-- `compute`: All Slurm compute nodes.
-- `openhpc`: All Slurm nodes - default is the union of `control`, `login` and `compute` groups.
-- `cluster`: All nodes in the cluster - default is as for `openhpc` but this allows for e.g. separate monitoring nodes.
-- `nfs`: NFS servers or clients, e.g. might be `openhpc` group.
-- `builder`: Host to use to optionally build compute images - see separate documentation TODO:
-- `podman`: Hosts running containers via [podman](https://podman.io/) - defaults to union of `opendistro`, `kibana`, `filebeat` groups.
-- `prometheus`: Host for the [Prometheus monitoring server](https://prometheus.io/docs/introduction/overview/#architecture).
-- `grafana`: Host for the [Grafana visualisation server](https://grafana.com/docs/grafana/latest/getting-started/)
-- `alertmanager`: TODO:
-- `exporters`: TODO: delete, unused
-- `opendistro`: Host running ElasticSearch.
-- `kibana`: TODO:
-- `slurm_stats`: Host running tools to integrate Slurm's accounting information with ElasticSearch. Host must be in both groups `openhpc` group (for `sacct` command) and `opendistro`.
-- `filebeat`: TODO:
-- `mysql`: TODO:
-- `node_exporter`: Hosts to export hardware and OS metrics from using the [Prometheus node exporter](https://github.com/prometheus/node_exporter)
-- `openhpc_tests`: TODO: default: login + compute
-- `selinux`: TODO: default `cluster`
-
 
 ## Adding new functionality
-TODO: this is just rough notes.
-Update:
-- READMEs
-- `environments/common/inventory/groups`
-- Example groups file in `environments/common/layouts/everything`
-- default group vars
-
-
+TODO: this is just rough notes:
+- Add new plays into existing playbook, or add a new playbook and update `site.yml`.
+- Add new group into `environments/common/inventory/groups`
+- Add new default group vars.
+- Update example groups file `environments/common/layouts/everything`
+- Update READMEs.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,24 @@
-# Demos for OpenHPC on OpenStack
+# StackHPC Slurm Appliance
 
-Example slurm configuration demonstrating a production/development split. This deploys
-a battries included OpenHPC based slurm environment running on CentOS 8, along with
-a monitoring stack.
+This repository contains playbooks and configuration to define a Slurm-based HPC environment, including:
+- A Centos 8 and OpenHPC v2-based Slurm cluster with production-ready configuration.
+- Shared fileystem(s using NFS (with servers within or external to the cluster).
+- Slurm accounting using a MySQL backend.
+- A monitoring backend using Prometheus and an ElasticSearch.
+- Grafana with dashboards for both individual nodes and Slurm jobs.
+- Production-ready Slurm defaults for access and memory.
+- A Packer-based build pipeline for compute node images.
+
+The repository is designed to be forked once for a specific use-case/HPC site containing multiple environments (e.g. development, staging and production). It has been designed to be modular and extensible, so if you add features for your HPC site please feel free to submit PRs back upstream to us!
 
 ## Pre-requisites
 
 - Working DNS so that we can use the ansible inventory name as the address for connecting to services.
+- Bootable images based on Centos 8 Cloud images.
 
-## Installation
+## Installation on deployment host
+
+These instructions assume the deployment host is running Centos 8:
 
     git clone  git@github.com:stackhpc/openhpc-demo.git
     cd openhpc-demo
@@ -18,43 +28,37 @@ a monitoring stack.
     pip install -r requirements.txt
     # Install ansible dependencies ...
     ansible-galaxy role install -r requirements.yml -p ansible/roles
-    ansible-galaxy collection install -r requirements.yml -p ansible/collections
+    ansible-galaxy collection install -r requirements.yml -p ansible/collections # ignore the path warning here
 
-## Directory structure
+## Overview of directory structure
 
-NOTE: This is just an overview, please see the `README.md` in the relevant directory
-for more details.
+Further information on each of these is provided in the relevent directory's `README.md`.
 
 ### environments
 
-This repository contains the configuration for multiple different environments. The
-configurations can be found in this directory.
+Contains configurations for both a "common" environment and one or more environments derived from this for your site.
+
+Environments define ansible inventory and may also contain provisioning code such as Terraform or OpenStack HEAT templates.
+
+**NB:** All commands described below require an environment to be "activated" to set appropriate environment variables:
+
+    source environments/<environment>activate
+
+How to create and modify an environment is described below.
 
 ### ansible
 
-Prerequisite: You must have provisioned the infrastructure prior to running this step. See
-`README.md` in environment folder for details.
+Contains the ansible playbooks to configure the infrastruture.
 
-Contains all the ansible playbooks to configure the infrastruture.
+Once an environment has been activated as above, the following will run all configuration:
 
-You must `activate` an environment prior to running any scripts.
-This sets environment variables which allow the scripts to locate the
-environment specific config. For example, to activate the `minimal` environment:
-
-    source environments/minimal/activate
     ansible-playbook ansible/site.yml
 
 ### packer
 
-Images for the compute nodes can be built in advance. This contains the packer
-configuration to build the compute images. These can be used for upgrading an
-existing cluster or for deploying the original set of compute nodes.
+Images for the compute nodes can be built using the Packer in this director These can be used for upgrading an
+existing cluster or for initial deployment of a set of compute nodes. Once an environment has been activated, run:
 
-You must `activate` an environment prior to running any scripts.
-This sets environment variables which allow the scripts to locate the
-environment specific config. For example, to activate the `minimal` environment:
-
-    source environments/minimal/activate
     cd packer
      ~/.local/bin/packer build --on-error=ask main.pkr.hcl
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # StackHPC Slurm Appliance
 
-This repository contains playbooks and configuration to define a Slurm-based HPC environment, including:
-- A Centos 8 and OpenHPC v2-based Slurm cluster with production-ready configuration.
-- Shared fileystem(s using NFS (with servers within or external to the cluster).
+This repository contains playbooks and configuration to define a Slurm-based HPC environment including:
+- A Centos 8 and OpenHPC v2-based Slurm cluster.
+- Shared fileystem(s) using NFS (with servers within or external to the cluster).
 - Slurm accounting using a MySQL backend.
-- A monitoring backend using Prometheus and an ElasticSearch.
+- A monitoring backend using Prometheus and ElasticSearch.
 - Grafana with dashboards for both individual nodes and Slurm jobs.
 - Production-ready Slurm defaults for access and memory.
 - A Packer-based build pipeline for compute node images.
 
-The repository is designed to be forked once for a specific use-case/HPC site containing multiple environments (e.g. development, staging and production). It has been designed to be modular and extensible, so if you add features for your HPC site please feel free to submit PRs back upstream to us!
+The repository is designed to be forked for a specific use-case/HPC site but can contain multiple environments (e.g. development, staging and production). It has been designed to be modular and extensible, so if you add features for your HPC site please feel free to submit PRs back upstream to us!
 
 ## Pre-requisites
 
@@ -33,17 +33,15 @@ These instructions assume the deployment host is running Centos 8:
 
 ## Overview of directory structure
 
-Further information on each of these is provided in the relevent directory's `README.md`.
-
 - `environments/`: Contains configurations for both a "common" environment and one or more environments derived from this for your site. These define ansible inventory and may also contain provisioning automation such as Terraform or OpenStack HEAT templates.
 - `ansible/`: Contains the ansible playbooks to configure the infrastruture.
-- `packer/`: Contains automation to use Packer to build compute nodes for an enviromment.
+- `packer/`: Contains automation to use Packer to build compute nodes for an enviromment - see the README in this directory for further information.
 
 ## Creating a Slurm appliance
 
 NB: This section describes generic instructions - check for any environment-specific instructions in `environments/<environment>/README.md` before starting.
 
-1. Activate the environment - this is REQUIRED before any other commands are run:
+1. Activate the environment - this **must be done** before any other commands are run:
 
         source environments/<environment>activate
 
@@ -71,23 +69,23 @@ NB: This section describes generic instructions - check for any environment-spec
     Tags as defined in the various sub-playbooks defined in `ansible/` may be used to only run part of the `site` tasks.
 
 
-5. TODO: testing? and other ad-hoc?
+5. **TODO:** testing? and other ad-hoc?
 
 ## Environments
 
-An environment is a directory which defines all the configuration for instantiations of this Slurm appliance at one site. A cookiecutter command is described below provided to create a new environment from a template.
+An environment is a directory which defines all the configuration for a single instantiation of this Slurm appliance. A `cookiecutter` command is described below to create a new environment from a template.
 
-Amongst other things, an environments's `activate` script defines the path to a custom `ansible.cfg` which itself defines the paths to inventory directories. Therefore no inventory paths need to be specified to ansible once an environment is activated. All environments include `environments/common/inventory` as the first inventory searched, with the environment-specific inventory then overriding parts of this.
+Amongst other things, an environments's `activate` script defines the path to a custom `ansible.cfg` which itself defines the paths to ansible inventory directories. Therefore no inventory paths need to be specified on the command-line once an environment is activated. All environments load `environments/common/inventory` first, with an environment-specific inventory then overriding parts of this as required.
 
 This repository generally follows a convention where:
-- Functionality is defined in terms of ansible roles applied to a a group of the same name, e.g. `openhpc` or `grafana`. The empty groups in the `common` invenvory mean that functionality is disabled by default, and must be enabled for a specific environment by adding hosts or child groups to the group in an environment-specific `environments/<environment>/inventory/groups` file. The meaning of the groups is described below.
-- Environment-specific variables for each role/group can be defined in a group_vars directory of the same name in `environments/<environment>/inventory/group_vars/<group_name>/overrides.yml`. These override any default values specified in `environments/common/inventory/group_vars/all/<group_name>.yml` (the use of `all` here is due to ansible's precedence rules).
+- Functionality is defined in terms of ansible roles applied to a a group of the same name, e.g. `openhpc` or `grafana`. The empty groups in the `common` invenvory mean that functionality is disabled by default, and must be enabled for a specific environment by adding hosts (or child groups) to the relevant group in an environment-specific `environments/<environment>/inventory/groups` file. The purpose of each group is described below.
+- Environment-specific variables for each role/group can be defined in a `group_vars/` directory of the same name in `environments/<environment>/inventory/group_vars/<group_name>/overrides.yml`. These override any default values specified in `environments/common/inventory/group_vars/all/<group_name>.yml` (the use of `all` here is due to ansible's precedence rules).
 
 An environment may also contain "hooks" which are ansible playbooks to run before or after the tasks defined in `ansible/site.yml`.
 
 ### Creating a new environment
 
-This repo contains a `cookiecutter` template which can be used to create a new environment from scratch. Run [installation on deployment host](#Installation-on-deployment-host) instructions above, then in the repo root run:
+This repo contains a `cookiecutter` template which can be used to create a new environment from scratch. Run the [installation on deployment host](#Installation-on-deployment-host) instructions above, then in the repo root run:
 
     . venv/bin/activate
     cookiecutter environments/skeleton
@@ -96,10 +94,9 @@ and follow the prompts to complete the environment name and description.
 
 Alternatively, you could copy an existing environment directory.
 
-Now add deployment automation, if required, and then complete the [environment-specific inventory](#Environment-specific-inventory). 
+Now add deployment automation if required, and then complete the [environment-specific inventory](#Environment-specific-inventory). 
 
-TODO: and  mention layout files.
-
+TODO:  mention layout files.
 
 ### Environment-specific inventory
 

--- a/README.md
+++ b/README.md
@@ -30,39 +30,33 @@ These instructions assume the deployment host is running Centos 8:
     ansible-galaxy role install -r requirements.yml -p ansible/roles
     ansible-galaxy collection install -r requirements.yml -p ansible/collections # ignore the path warning here
 
+
 ## Overview of directory structure
 
 Further information on each of these is provided in the relevent directory's `README.md`.
 
-### environments
+- `environments/`: Contains configurations for both a "common" environment and one or more environments derived from this for your site. These define ansible inventory and may also contain provisioning automation such as Terraform or OpenStack HEAT templates.
+- `ansible/`: Contains the ansible playbooks to configure the infrastruture.
+- `packer/`: Contains automation to use Packer to build compute nodes for an enviromment.
 
-Contains configurations for both a "common" environment and one or more environments derived from this for your site.
+## Creating a Slurm appliance
 
-Environments define ansible inventory and may also contain provisioning code such as Terraform or OpenStack HEAT templates.
+NB: This section describes generic instructions - check for any environment-specific instructions in `environments/<environment>/README.md` before starting.
 
-**NB:** All commands described below require an environment to be "activated" to set appropriate environment variables:
+1. Activate the environment - this is REQUIRED before any other commands are run:
 
     source environments/<environment>activate
 
-How to create and modify an environment is described below.
+2. Deploy instances - see environment-specific instructions.
 
-### ansible
+3. Generate passwords:
 
-Contains the ansible playbooks to configure the infrastruture.
+    ansible-playbook ansible/adhoc/generate-passwords.yml
 
-Once an environment has been activated as above, the following will run all configuration:
+4. Deploy the appliance:
 
     ansible-playbook ansible/site.yml
 
-### packer
-
-Images for the compute nodes can be built using the Packer in this director These can be used for upgrading an
-existing cluster or for initial deployment of a set of compute nodes. Once an environment has been activated, run:
-
-    cd packer
-     ~/.local/bin/packer build --on-error=ask main.pkr.hcl
-
-See `packer/README.md` for more details.
 
 ## Environments
 
@@ -85,3 +79,6 @@ TODO:
 ### Groups
 
 TODO:
+
+# TODO
+Document passwords

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ Although most of the inventory uses the group convention described above there a
 - The `control`, `login` and `compute` groups are special as they need to contain actual hosts rather than child groups, and so should generally be defined in the templated-out `hosts` file.
 - The cluster name must be set on all hosts using `openhpc_cluster_name`. Using an  `[all:vars]` section in the `hosts` file is usually convenient.
 - `environments/common/inventory/group_vars/all/defaults.yml` contains some variables which are not associated with a specific role/feature. These are unlikely to need changing, but if necessary that could be done using a `environments/<environment>/inventory/group_vars/all/overrides.yml` file.
+- The `ansible/adhoc/generate-passwords.yml` playbook sets secrets for all hosts in `environments/<environent>/inventory/group_vars/all/secrets.yml`.
+- The Packer-based pipeline for building compute images creates a VM in groups `builder` and `compute`, allowing build-specific properties to be set in `environments/common/inventory/group_vars/builder/defaults.yml` or the equivalent inventory-specific path.
 - Each Slurm partition must have:
     - An inventory group `<cluster_name>_<partition_name>` defining the hosts it contains - these must be homogenous w.r.t CPU and memory.
     - An entry in the `openhpc_slurm_partitions` mapping in `environments/<environment>/inventory/group_vars/openhpc/overrides.yml`.
@@ -123,7 +125,8 @@ Although most of the inventory uses the group convention described above there a
 ## Adding new functionality
 TODO: this is just rough notes:
 - Add new plays into existing playbook, or add a new playbook and update `site.yml`.
-- Add new group into `environments/common/inventory/groups`
+- Add new empty group into `environments/common/inventory/groups`
 - Add new default group vars.
 - Update example groups file `environments/common/layouts/everything`
+- Update default Packer build variables in `environments/common/inventory/group_vars/builder/defaults.yml`.
 - Update READMEs.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ This repository generally follows a convention where:
 - Functionality is defined in terms of ansible roles applied to a a group of the same name, e.g. `openhpc` or `grafana`. The empty groups in the `common` invenvory mean that functionality is disabled by default, and must be enabled for a specific environment by adding hosts or child groups to the group in an environment-specific `environments/<environment>/inventory/groups` file. The meaning of the groups is described below.
 - Environment-specific variables for each role/group can be defined in a group_vars directory of the same name in `environments/<environment>/inventory/group_vars/<group_name>/overrides.yml`. These override any default values specified in `environments/common/inventory/group_vars/all/<group_name>.yml` (the use of `all` here is due to ansible's precedence rules).
 
+TODO: Document hooks
+
 ### Creating a new environment
 
 TODO: and  mention layout files.
@@ -89,9 +91,17 @@ TODO: and  mention layout files.
 
 TODO:
 
-### Groups
+### Environment-specific inventory
 
-TODO:
+This section describes how to structure an environment
 
-# TODO
-Document passwords
+- The hosts should be listed in a file `environments/<environment>/inventory/hosts`. This is usually created by the deployment automation and should define the following groups:
+    - `control`: A single host for the Slurm control node. Multiple (high availability) control nodes are not supported.
+    - `login`: One or more hosts for Slurm login nodes. Combined control/login nodes are not supported.
+    - `compute`: Hosts for all Slurm compute nodes.
+- The cluster name must be defined for all hosts using `openhpc_cluster_name`. Setting this in the above hosts file using `[all:vars]` is usually convenient.
+- Each Slurm partition must contain a homogeneous set of hosts. For each partition:
+    - Define an ansible inventory group for each partition as `<cluster_name>_<partition_name>`.
+    - Define the partition by setting openhpc_slurm_partitions in `environments/<environment>/inventory/group_vars/openhpc/overrides.yml`.
+  
+  See the [openhpc role documentation](https://github.com/stackhpc/ansible-role-openhpc#slurmconf) for more options.

--- a/README.md
+++ b/README.md
@@ -45,17 +45,30 @@ NB: This section describes generic instructions - check for any environment-spec
 
 1. Activate the environment - this is REQUIRED before any other commands are run:
 
-    source environments/<environment>activate
+        source environments/<environment>activate
 
 2. Deploy instances - see environment-specific instructions.
 
 3. Generate passwords:
 
-    ansible-playbook ansible/adhoc/generate-passwords.yml
+        ansible-playbook ansible/adhoc/generate-passwords.yml
+
+    This will output a set of passwords in `environments/<environment>/inventory/group_vars/all/secrets.yml`. It is recommended that these are encrpyted and then commited to git using:
+
+        ansible-vault encrypt inventory/group_vars/all/secrets.yml
+   
+    See the [Ansible vault documentation](https://docs.ansible.com/ansible/latest/user_guide/vault.html) for more details.
+
 
 4. Deploy the appliance:
 
-    ansible-playbook ansible/site.yml
+        ansible-playbook ansible/site.yml
+
+   or if you have encrypted secrets use:
+
+        ansible-playbook ansible/site.yml --ask-vault-password
+
+    Tags as defined in the various sub-playbooks defined in `ansible/` may be used to only run part of the `site` tasks.
 
 
 ## Environments

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ NB: This section describes generic instructions - check for any environment-spec
     Tags as defined in the various sub-playbooks defined in `ansible/` may be used to only run part of the `site` tasks.
 
 
+5. TODO: testing? and other ad-hoc?
+
 ## Environments
 
 An environment is a directory which defines all the configuration for instantiations of this Slurm appliance at one site. A cookiecutter command is described below provided to create a new environment from a template.
@@ -81,27 +83,71 @@ This repository generally follows a convention where:
 - Functionality is defined in terms of ansible roles applied to a a group of the same name, e.g. `openhpc` or `grafana`. The empty groups in the `common` invenvory mean that functionality is disabled by default, and must be enabled for a specific environment by adding hosts or child groups to the group in an environment-specific `environments/<environment>/inventory/groups` file. The meaning of the groups is described below.
 - Environment-specific variables for each role/group can be defined in a group_vars directory of the same name in `environments/<environment>/inventory/group_vars/<group_name>/overrides.yml`. These override any default values specified in `environments/common/inventory/group_vars/all/<group_name>.yml` (the use of `all` here is due to ansible's precedence rules).
 
-TODO: Document hooks
+An environment may also contain "hooks" which are ansible playbooks to run before or after the tasks defined in `ansible/site.yml`.
 
 ### Creating a new environment
 
+This repo contains a `cookiecutter` template which can be used to create a new environment from scratch. Run [installation on deployment host](#Installation-on-deployment-host) instructions above, then in the repo root run:
+
+    . venv/bin/activate
+    cookiecutter environments/skeleton
+
+and follow the prompts to complete the environment name and description.
+
+Alternatively, you could copy an existing environment directory.
+
+Now add deployment automation, if required, and then complete the [environment-specific inventory](#Environment-specific-inventory). 
+
 TODO: and  mention layout files.
 
-### Modifying an environment
-
-TODO:
 
 ### Environment-specific inventory
 
-This section describes how to structure an environment
+This section describes how to structure the inventory in an environment.
 
-- The hosts should be listed in a file `environments/<environment>/inventory/hosts`. This is usually created by the deployment automation and should define the following groups:
+1. The hosts should be listed in a file `environments/<environment>/inventory/hosts`. This is usually created by the deployment automation and should define the following groups:
     - `control`: A single host for the Slurm control node. Multiple (high availability) control nodes are not supported.
     - `login`: One or more hosts for Slurm login nodes. Combined control/login nodes are not supported.
     - `compute`: Hosts for all Slurm compute nodes.
-- The cluster name must be defined for all hosts using `openhpc_cluster_name`. Setting this in the above hosts file using `[all:vars]` is usually convenient.
-- Each Slurm partition must contain a homogeneous set of hosts. For each partition:
+1. The cluster name must be defined for all hosts using `openhpc_cluster_name`. Setting this in the above hosts file using `[all:vars]` is usually convenient.
+1. Each Slurm partition must contain a homogeneous set of hosts. For each partition:
     - Define an ansible inventory group for each partition as `<cluster_name>_<partition_name>`.
     - Define the partition by setting openhpc_slurm_partitions in `environments/<environment>/inventory/group_vars/openhpc/overrides.yml`.
   
   See the [openhpc role documentation](https://github.com/stackhpc/ansible-role-openhpc#slurmconf) for more options.
+1. The required groups must be defined in `environments/<environment>/inventory/groups` as described TODO. Note that `environments/common/layouts/` contains `minimal` and `everything` example groups files which should generally form a good basis for a new environment.
+
+## Inventory groups
+
+This repo defines the following groups:
+- `control`: A single Slurm control node. Multiple (high availability) control nodes are not supported.
+- `login`: One Slurm login nodes. Combined control/login nodes are not supported.
+- `compute`: All Slurm compute nodes.
+- `openhpc`: All Slurm nodes - default is the union of `control`, `login` and `compute` groups.
+- `cluster`: All nodes in the cluster - default is as for `openhpc` but this allows for e.g. separate monitoring nodes.
+- `nfs`: NFS servers or clients, e.g. might be `openhpc` group.
+- `builder`: Host to use to optionally build compute images - see separate documentation TODO:
+- `podman`: Hosts running containers via [podman](https://podman.io/) - defaults to union of `opendistro`, `kibana`, `filebeat` groups.
+- `prometheus`: Host for the [Prometheus monitoring server](https://prometheus.io/docs/introduction/overview/#architecture).
+- `grafana`: Host for the [Grafana visualisation server](https://grafana.com/docs/grafana/latest/getting-started/)
+- `alertmanager`: TODO:
+- `exporters`: TODO: delete, unused
+- `opendistro`: Host running ElasticSearch.
+- `kibana`: TODO:
+- `slurm_stats`: Host running tools to integrate Slurm's accounting information with ElasticSearch. Host must be in both groups `openhpc` group (for `sacct` command) and `opendistro`.
+- `filebeat`: TODO:
+- `mysql`: TODO:
+- `node_exporter`: Hosts to export hardware and OS metrics from using the [Prometheus node exporter](https://github.com/prometheus/node_exporter)
+- `openhpc_tests`: TODO: default: login + compute
+- `selinux`: TODO: default `cluster`
+
+
+## Adding new functionality
+TODO: this is just rough notes.
+Update:
+- READMEs
+- `environments/common/inventory/groups`
+- Example groups file in `environments/common/layouts/everything`
+- default group vars
+
+

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ These instructions assume the deployment host is running Centos 8:
 - `environments/`: Contains configurations for both a "common" environment and one or more environments derived from this for your site. These define ansible inventory and may also contain provisioning automation such as Terraform or OpenStack HEAT templates.
 - `ansible/`: Contains the ansible playbooks to configure the infrastruture.
 - `packer/`: Contains automation to use Packer to build compute nodes for an enviromment - see the README in this directory for further information.
+- `dev/`: Contains development tools.
 
 ## Creating a Slurm appliance
 

--- a/environments/common/inventory/groups
+++ b/environments/common/inventory/groups
@@ -20,7 +20,7 @@ control
 compute
 
 [builder]
-# Host for (optionally) building compute images - see separate documentation.
+# VM used to (optionally) build compute images - do not add hosts. See packer/README.md.
 
 [podman:children]
 # Hosts running containers for below services:

--- a/environments/common/inventory/groups
+++ b/environments/common/inventory/groups
@@ -1,49 +1,68 @@
-[cluster]
-
 [login]
+# Slurm login nodes. Combined control/login nodes are not supported.
 
 [control]
+# A single Slurm control node. Multiple (high availability) control nodes are not supported.
 
 [compute]
+# All Slurm compute nodes (in all partitions).
 
-[builder]
+[openhpc]
+# All Slurm nodes
+
+[cluster]
+# All nodes in the appliance - this allows for e.g. specific service nodes not running Slurm.
+# See default below.
 
 [cluster:children]
 login
 control
 compute
 
+[builder]
+# Host for (optionally) building compute images - see separate documentation.
+
 [podman:children]
+# Hosts running containers for below services:
 opendistro
 kibana
 filebeat
 
 [prometheus]
+# Monitoring server(s)
 
 [grafana]
+# Dashboard server(s)
 
 [alertmanager]
-
-[exporters]
+# TODO:
 
 [opendistro]
+# ElasticSearch server, used for Slurm monitoring.
 
 [kibana]
+# TODO:
 
 [slurm_stats]
+# Runs tools to integrate Slurm's accounting information with ElasticSearch.
+# NB: Host must be in `openhpc` group (for `sacct` command) and `opendistro` group.
 
 [filebeat]
+# TODO:
 
 [nfs]
-
-[openhpc]
+# NFS servers or clients.
 
 [mysql]
+# Runs database used for Slurm accounting.
 
 [node_exporter]
+# Monitor these hosts for hardware and OS metrics
 
 [openhpc_tests:children]
-cluster
+# Run post-deploy MPI-based tests using ansible/adhoc/test.yml
+cluster # TODO: FIXME in branch
 
 [selinux:children]
+# Define selinux status for these
 cluster


### PR DESCRIPTION
Add documentation to close #11 and #13.

As per discussion with @jovial  will aim for READMEs in environments to *only* cover aspects specific to that environment - everything else should be documented in the root README, or signposted there and covered in a directory-specific README (e.g. `packer/README.md`.

