### PR TITLE
Define NFS config using multiple-configuration approach

### DIFF
--- a/ansible/filesystems.yml
+++ b/ansible/filesystems.yml
@@ -8,8 +8,3 @@
   tasks:
     - include_role:
         name: stackhpc.nfs
-      vars:
-        nfs_enable: "{{ nfs_configuration.nfs_enable }}"
-        nfs_server: "{{ nfs_configuration.nfs_server }}"
-        nfs_export: "{{ nfs_configuration.nfs_export }}"
-        nfs_client_mnt_point: "{{ nfs_configuration.nfs_client_mnt_point }}"

--- a/environments/common/inventory/group_vars/all/nfs.yml
+++ b/environments/common/inventory/group_vars/all/nfs.yml
@@ -2,13 +2,13 @@
 
 nfs_server_default: "{{ hostvars[groups['control'] | first ].internal_address }}"
 
-nfs_configuration:
-  nfs_enable:
-      server:  "{{ inventory_hostname in groups['control'] }}"
-      # Don't mount share on server where it is exported from...
-      # Could do something like nfs_clients: '"nfs_servers" not in group_names' instead.
-      # See also constructed inventory: https://docs.ansible.com/ansible/devel/collections/ansible/builtin/constructed_inventory.html
-      clients: "{{ inventory_hostname in groups['cluster'] and inventory_hostname not in groups['control'] }}"
-  nfs_server: "{{ nfs_server_default }}"
-  nfs_export: "/mnt/nfs/"
-  nfs_client_mnt_point: "/mnt/nfs/"
+nfs_configurations:
+  - nfs_enable:
+        server:  "{{ inventory_hostname in groups['control'] }}"
+        # Don't mount share on server where it is exported from...
+        # Could do something like nfs_clients: '"nfs_servers" not in group_names' instead.
+        # See also constructed inventory: https://docs.ansible.com/ansible/devel/collections/ansible/builtin/constructed_inventory.html
+        clients: "{{ inventory_hostname in groups['cluster'] and inventory_hostname not in groups['control'] }}"
+    nfs_server: "{{ nfs_server_default }}"
+    nfs_export: "/mnt/nfs/"
+    nfs_client_mnt_point: "/mnt/nfs/"


### PR DESCRIPTION
Now the NFS role on Galaxy supports multiple configurations and the requirements.yml is updated to use that, we can define the default NFS config using this method which makes it easier to modify for multiple configs.