### PR TITLE
cloudalchemy.node-exporter -> cloudalchemy.node_exporter

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -2,7 +2,7 @@
 roles:
   - src: stackhpc.nfs
   - src: stackhpc.openhpc
-  - src: cloudalchemy.node-exporter
+  - src: cloudalchemy.node_exporter
   - src: cloudalchemy.blackbox-exporter
   - src: cloudalchemy.prometheus
   - src: cloudalchemy.alertmanager


### PR DESCRIPTION
The name has changed in galaxy and there is no redirect, see: https://github.com/cloudalchemy/ansible-node-exporter/commit/1708022d3e682fe6220472ac32417bc13262d25b