### PR TITLE
update facts when SELinux status changed

### DIFF
--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -27,3 +27,6 @@
         delay: 30
         sleep: 5
       when: sestatus.reboot_required
+    - name: update facts
+      setup:
+      when: sestatus.changed


### PR DESCRIPTION
`cloudalchemy.node_exporter/tasks/configure.yml` has a task:

```
- name: Allow node_exporter port in SELinux on RedHat OS family
<snip>
  when:
    - ansible_version.full is version_compare('2.4', '>=')
    - ansible_selinux.status == "enabled"
```

Without this PR, if selinux is changed from enabled to disabled by bootstrap.yml, this change isn't reflected in the facts, and then the task fails with an error that selinux is disabled.