### PR TITLE
Update libgcrypt in packer docs

### DIFF
--- a/packer/README.md
+++ b/packer/README.md
@@ -12,11 +12,12 @@ Steps:
 
 - Follow the standard installation instructions in the main README.
 
-- Install packer and qemu-kvm:
+- Install packer and qemu-kvm, and ensure libgcrypt is updated:
 
       sudo yum-config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo
       sudo yum -y install packer
       sudo yum -y install qemu-kvm
+      sudo yum -y install libgcrypt
 
 - Activate the venv and the relevant environment.
 - Ensure you have generated passwords using:


### PR DESCRIPTION
Using a CentOS 8.3 deploy host hits this issue when running packer: https://bugzilla.redhat.com/show_bug.cgi?id=1828681.

Fixed by updating libgcrypt.