### PR TITLE
Fix rebuild role fail in packer build

### DIFF
--- a/environments/common/inventory/group_vars/builder/defaults.yml
+++ b/environments/common/inventory/group_vars/builder/defaults.yml
@@ -4,3 +4,4 @@
 # defined elsewhere the group that is ordered lower will determine the values.
 openhpc_slurm_service_started: false
 nfs_client_mnt_state: present
+openhpc_rebuild_reconfigure: false


### PR DESCRIPTION
Fixes #55 - need to disable the `scontrol reconfigure` when running inside packer as slurm isn't running.

Have raised https://github.com/stackhpc/ansible_collection_slurm_openstack_tools/issues/28 to improve the reconfigure task, separately.