### PR TITLE
Make packer VM disk size configurable

### DIFF
--- a/packer/README.md
+++ b/packer/README.md
@@ -36,6 +36,10 @@ Steps:
         # or during development:
         PACKER_LOG=1 packer build --on-error=ask main.pkr.hcl
 
+  By default this creates a 20GB image. For nodes with smaller disks pass `disk_size` to packer ([docs](https://www.packer.io/docs/builders/qemu#disk_size)), e.g:
+
+        packer build -var 'disk_size=10G' ...
+  
 - For debugging, you can login to the VM over ssh by finding the line like the following in the Packer output:
 
         Executing /usr/libexec/qemu-kvm: ...  "-netdev", "user,id=user.0,hostfwd=tcp::2922-:22", ... 

--- a/packer/main.pkr.hcl
+++ b/packer/main.pkr.hcl
@@ -11,11 +11,17 @@ variable "environment_root" {
   type = string
 }
 
+# VM disk size - needs to match compute VM image
+variable "disk_size" {
+  type = string
+  default = "20G"
+}
+
 source "qemu" "openhpc-compute" {
   iso_url = "https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.2.2004-20200611.2.x86_64.qcow2"
   iso_checksum = "sha256:d8984b9baee57b127abce310def0f4c3c9d5b3cea7ea8451fc4ffcbc9935b640"
   disk_image = true # as above is .qcow2 not .iso
-  disk_size = "20G" # needs to match compute VM
+  disk_size = var.disk_size
   disk_compression = true
   accelerator      = "kvm" # default, if available
   ssh_username = "centos"


### PR DESCRIPTION
Enables booting the built image on small nodes e.g. for testing.