### PR TITLE
Use RockyLinux 9 for CI by default

### DIFF
--- a/.github/workflows/fatimage.yml
+++ b/.github/workflows/fatimage.yml
@@ -3,9 +3,9 @@ name: Build fat image
 'on':
   workflow_dispatch:
     inputs:
-      use_RL9:
+      use_RL8:
         required: true
-        description: Include RL9 image build
+        description: Include RL8 image build
         type: boolean
         default: false
 jobs:
@@ -16,11 +16,11 @@ jobs:
     strategy:
       matrix:
         os_version: [RL8, RL9]
-        rl9_selected:
-          - ${{ inputs.use_RL9 == true }} # only potentially true for workflow_dispatch
+        rl8_selected:
+          - ${{ inputs.use_RL8 == true }} # only potentially true for workflow_dispatch
         exclude:
-          - os_version: RL9
-            rl9_selected: false
+          - os_version: RL8
+            rl8_selected: false
     env:
       ANSIBLE_FORCE_COLOR: True
       OS_CLOUD: openstack

--- a/.github/workflows/stackhpc.yml
+++ b/.github/workflows/stackhpc.yml
@@ -3,9 +3,9 @@ name: Test deployment and reimage on OpenStack
 on:
   workflow_dispatch:
     inputs:
-      use_RL9:
+      use_RL8:
         required: true
-        description: Include RL9 tests
+        description: Include RL8 tests
         type: boolean
         default: false
   push:
@@ -20,14 +20,14 @@ jobs:
     strategy:
       matrix:
         os_version: [RL8, RL9]
-        rl9_selected:
-          - ${{ inputs.use_RL9 == true }} # only potentially true for workflow_dispatch
-        rl9_branch:
-          - ${{ startsWith(github.head_ref, 'rl9') == true }} # only potentially for pull_request, always false on merge
+        rl8_selected:
+          - ${{ inputs.use_RL8 == true }} # only potentially true for workflow_dispatch
+        rl8_branch:
+          - ${{ startsWith(github.head_ref, 'rl8') == true }} # only potentially for pull_request, always false on merge
         exclude:
-          - os_version: RL9
-            rl9_selected: false
-            rl9_branch: false
+          - os_version: RL8
+            rl8_selected: false
+            rl8_branch: false
     env:
       ANSIBLE_FORCE_COLOR: True
       OS_CLOUD: openstack


### PR DESCRIPTION
Makes RL9 the default for image builds and test and makes RL9 optional.