### PR TITLE
Ignore changes block-device in compute_fixed_image

### DIFF
--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/node_group/nodes.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/node_group/nodes.tf
@@ -115,6 +115,7 @@ resource "openstack_compute_instance_v2" "compute_fixed_image" {
   lifecycle {
     ignore_changes = [
       image_id,
+      block_device,
     ]
   }
 


### PR DESCRIPTION
Fixes slurm controlled rebuild for volume backed instances.

This is required because image_id is used in the block device.