### PR TITLE
Change host definition for cacert play to allow builder

### DIFF
--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -143,7 +143,7 @@
       - appliances_mode == 'configure'
       - not (dnf_repos_allow_insecure_creds | default(false)) # useful for development
 
-- hosts: cacerts:!builder
+- hosts: cacerts
   tags: cacerts
   gather_facts: false
   tasks:


### PR DESCRIPTION
Allows the cacerts role to be run on the builder group. 