### PR TITLE
CI: Use GitHub token for Packer workflows

### DIFF
--- a/.github/workflows/extra.yml
+++ b/.github/workflows/extra.yml
@@ -43,6 +43,7 @@ jobs:
       OS_CLOUD: openstack
       CI_CLOUD: ${{ vars.CI_CLOUD }} # default from repo settings
       ARK_PASSWORD: ${{ secrets.ARK_PASSWORD }}
+      PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@v2
@@ -95,7 +96,7 @@ jobs:
           . environments/.stackhpc/activate
           cd packer/
           packer init .
-          
+
           PACKER_LOG=1 packer build \
           -on-error=${{ vars.PACKER_ON_ERROR }} \
           -var-file=$PKR_VAR_environment_root/${{ env.CI_CLOUD }}.pkrvars.hcl \
@@ -104,7 +105,7 @@ jobs:
           -var "inventory_groups=${{ matrix.build.inventory_groups }}" \
           -var "volume_size=${{ matrix.build.volume_size }}" \
           openstack.pkr.hcl
-        
+
       - name: Get created image names from manifest
         id: manifest
         run: |

--- a/.github/workflows/fatimage.yml
+++ b/.github/workflows/fatimage.yml
@@ -39,6 +39,7 @@ jobs:
       CI_CLOUD: ${{ github.event.inputs.ci_cloud }}
       ARK_PASSWORD: ${{ secrets.ARK_PASSWORD }}
       LEAFCLOUD_PULP_PASSWORD: ${{ secrets.LEAFCLOUD_PULP_PASSWORD }}
+      PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/nightlybuild.yml
+++ b/.github/workflows/nightlybuild.yml
@@ -36,6 +36,7 @@ jobs:
       CI_CLOUD: ${{ github.event.inputs.ci_cloud || vars.CI_CLOUD }}
       ARK_PASSWORD: ${{ secrets.ARK_PASSWORD }}
       LEAFCLOUD_PULP_PASSWORD: ${{ secrets.LEAFCLOUD_PULP_PASSWORD }}
+      PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Packer workflows sometimes fail due to rate limits of the GitHub API:

    Failed getting the "github.com/ethanmdavidson/git" plugin:
    1 error occurred:
    	* Plugin host rate limited the plugin getter. Try again in 3m52.820898337s. HINT: Set the PACKER_GITHUB_API_TOKEN env var with a token to get more requests.

Set PACKER_GITHUB_API_TOKEN [1] to GITHUB_TOKEN [2] to reduce failures.

[1] https://developer.hashicorp.com/packer/docs/configure#packer_github_api_token
[2] https://docs.github.com/en/actions/concepts/security/github_token