### PR TITLE
Allow using a specific FIP for a build VM

### DIFF
--- a/packer/openstack.pkr.hcl
+++ b/packer/openstack.pkr.hcl
@@ -104,6 +104,7 @@ variable "floating_ip_network" {
 
 variable "floating_ip" {
   type = string
+  description = "ID of pre-existing FIP to attach. Note floating_ip_network is not required when using this"
   default = null
 }
 


### PR DESCRIPTION
Adds packer variable `floating_ip` to allow selecting (by ID) a FIP which is already in the project to use as the build VM FIP.

Tested on client site.