### PR TITLE
Add metadata service to no_proxy defaults

### DIFF
--- a/ansible/roles/proxy/defaults/main.yml
+++ b/ansible/roles/proxy/defaults/main.yml
@@ -1,6 +1,6 @@
 # proxy_http_proxy:
 proxy_https_proxy: "{{ proxy_http_proxy }}"
-proxy_no_proxy_defaults: "{{ ['localhost', '127.0.0.1'] + groups['all'] + hostvars.values() | map(attribute='ansible_host') }}"
+proxy_no_proxy_defaults: "{{ ['localhost', '127.0.0.1', '169.254.169.254'] + groups['all'] + hostvars.values() | map(attribute='ansible_host') }}"
 proxy_no_proxy_extras: []
 proxy_no_proxy: "{{ (proxy_no_proxy_defaults + proxy_no_proxy_extras) | unique | sort | join(',') }}"
 proxy_dnf: true


### PR DESCRIPTION
When using a proxy, normally requests to the metadata service should not go through the proxy.