### PR TITLE
Make rebuilding slurm optional for `cuda` builds

### DIFF
--- a/ansible/fatimage.yml
+++ b/ansible/fatimage.yml
@@ -262,7 +262,7 @@
         name: grafana-dashboards
 
 - name: Add support for NVIDIA GPU auto detection to Slurm
-  hosts: cuda
+  hosts: slurm_recompile
   become: yes
   tasks:
     - name: Recompile slurm

--- a/environments/common/inventory/groups
+++ b/environments/common/inventory/groups
@@ -118,6 +118,9 @@ freeipa_client
 [cuda]
 # Hosts to install NVIDIA CUDA on - see ansible/roles/cuda/README.md
 
+[slurm_recompile]
+# Hosts to recompile Slurm for - allows supporting Slurm autodetection method 'nvml'
+
 [vgpu]
 # Hosts where vGPU/MIG should be configured - see docs/mig.md
 

--- a/environments/common/layouts/everything
+++ b/environments/common/layouts/everything
@@ -65,6 +65,10 @@ cluster
 [cuda]
 # Hosts to install NVIDIA CUDA on - see ansible/roles/cuda/README.md
 
+[slurm_recompile:children]
+# Hosts to recompile Slurm for - allows supporting Slurm autodetection method 'nvml'
+cuda
+
 [eessi:children]
 # Hosts on which EESSI stack should be configured
 openhpc


### PR DESCRIPTION
If not using MIG or NVLINK GPUs, it is possible to use the `nvidia` [GRES autodetect mechanism](https://slurm.schedmd.com/gres.conf.html#OPT_AutoDetect) rather than the `nvml` one. The former does not require rebuilding slurm against the NVIDIA management libraries, so this can be skipped when building `cuda` images.

This does not change the current default.