### PR TITLE
Fix parse error in pingmatrix output

### DIFF
--- a/ansible/roles/hpctests/library/plot_nxnlatbw.py
+++ b/ansible/roles/hpctests/library/plot_nxnlatbw.py
@@ -129,7 +129,11 @@ def run_module():
             if len(vals) != 4:
                 print('warning: skipping line %i (%i values)' % (ln, len(vals)))
                 continue
-            rankA, rankB, lat, bw = int(vals[0]), int(vals[1]), float(vals[2]), float(vals[3])
+            try:
+                rankA, rankB, lat, bw = int(vals[0]), int(vals[1]), float(vals[2]), float(vals[3])
+            except ValueError:
+                print('warning: skipping line %i (%s) - parse failure' % (ln, line))
+                continue
             latencies[rankA, rankB] = lat
             bandwidths[rankA, rankB] = bw
     


### PR DESCRIPTION
When the line displaying the group of nodes used tokenises as four items, it results in a parse error when python attemmpts to cast the line as integers and floats.