### PR TITLE
Add validation for tofu-templated vars

### DIFF
--- a/ansible/validate.yml
+++ b/ansible/validate.yml
@@ -57,7 +57,10 @@
         that:
           - item in groups
           - groups[item] | length > 0
-        fail_msg: "Expected inventory group '{{ item }}' is missing or empty: is OpenTofu inventory template up to date?"
+        fail_msg: >
+          Expected inventory group '{{ item }}' is missing or empty:
+          - Check OpenTofu inventory template is up to date
+          - Check OpenTofu configuration defines 'login' and 'compute' variables properly
       loop:
         - control
         - compute


### PR DESCRIPTION
Will help catch errors if an Ansible update introduces a new variable provided by OpenTofu (e.g. when #666 added `compute_groups`) but the OpenTofu configurations haven't been correctly upgraded. Currently, this just leads to a templating error at some point during site.yml which is hard to debug.

This also "documents" the expected interface from OpenTofu to Ansible.