### PR TITLE
Pin bcrypt to 4.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ python-openstackclient==8.0.0
 python-manilaclient
 python-ironicclient
 jmespath
+bcrypt==4.3.0
 passlib[bcrypt]==1.7.4
 cookiecutter
 selinux # this is a shim to avoid having to use --system-site-packages, you still need sudo yum install libselinux-python3


### PR DESCRIPTION
bcrypt version used by passlib wasn't previously pinned, broken bcrypt 5.0.0 release is causing bug reported in in https://github.com/ansible/ansible/issues/85919