### PR TITLE
Add support for InfiniBand interfaces to NHC

### DIFF
--- a/ansible/roles/nhc/README.md
+++ b/ansible/roles/nhc/README.md
@@ -37,6 +37,7 @@ When the `ansible/site.yml` playbook is run this will automatically:
 
    - Filesystem mounts
    - Ethernet interfaces
+   - InfiniBand interfaces
 
    See `/etc/nhc/nhc.conf` on a compute node for the full configuration.
 

--- a/ansible/roles/nhc/templates/nhc.conf.j2
+++ b/ansible/roles/nhc/templates/nhc.conf.j2
@@ -16,5 +16,10 @@
 {{ ansible_fqdn }} || check_hw_eth {{ iface }}
 {% endfor %}
 
+## InfiniBand interface checks
+{% for iface in ansible_interfaces | select('match', 'ib') %}
+{{ ansible_fqdn }} || check_hw_ib {{ (ansible_facts[iface]['speed'] / 1000) | int }} {{ iface }}
+{% endfor %}
+
 ## Site-specific checks
 {{ nhc_config_extra }}


### PR DESCRIPTION
Tested on client system, resulting NHC config:


```
...
## InfiniBand interface checks
steveb-test-gpu-0.steveb-test.internal || check_hw_ib 400 ib1
steveb-test-gpu-0.steveb-test.internal || check_hw_ib 400 ib7
steveb-test-gpu-0.steveb-test.internal || check_hw_ib 400 ib3
steveb-test-gpu-0.steveb-test.internal || check_hw_ib 400 ib4
steveb-test-gpu-0.steveb-test.internal || check_hw_ib 400 ib6
steveb-test-gpu-0.steveb-test.internal || check_hw_ib 400 ib2
steveb-test-gpu-0.steveb-test.internal || check_hw_ib 400 ib0
steveb-test-gpu-0.steveb-test.internal || check_hw_ib 400 ib5
````