### PR TITLE
Bump OpenHPC role to v1.4.1

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -4,7 +4,7 @@ roles:
     version: v25.3.2
     name: stackhpc.nfs
   - src: https://github.com/stackhpc/ansible-role-openhpc.git
-    version: v1.4.0
+    version: v1.4.1
     name: stackhpc.openhpc
   - src: https://github.com/stackhpc/ansible-node-exporter.git
     version: stackhpc


### PR DESCRIPTION
Fix mpi.conf templating by @bertiethorpe in https://github.com/stackhpc/ansible-role-openhpc/pull/203