### PR TITLE
Allow fixed ip lists to be longer than nodes list

### DIFF
--- a/environments/site/tofu/node_group/variables.tf
+++ b/environments/site/tofu/node_group/variables.tf
@@ -135,11 +135,11 @@ variable "ip_addresses" {
   nullable    = false
   validation {
     condition     = length(setsubtract(keys(var.ip_addresses), var.networks[*].network)) == 0
-    error_message = "Keys in ip_addresses for nodegroup \"${var.group_name}\" must match network names in var.cluster_networks"
+    error_message = "Keys in ip_addresses for nodegroup \"${var.group_name}\" must match network names"
   }
   validation {
-    condition     = alltrue([for v in values(var.ip_addresses) : length(v) == length(var.nodes)])
-    error_message = "Values in ip_addresses for nodegroup \"${var.group_name}\" must be a list of the same length as var.nodes"
+    condition     = alltrue([for v in values(var.ip_addresses) : length(v) >= length(var.nodes)])
+    error_message = "Lists in ip_addresses for nodegroup \"${var.group_name}\" must be at least as long as the nodes list"
   }
 }
 


### PR DESCRIPTION
Moving baremetal nodes between e.g. production and staging is often necessary to test changes due to the limted number of them available. If these have fixed IPs specified via `ip_addresses` this change allows the IPs to be left while removing the actual nodes, which makes this move easier as the IP configuration can remain in source.

Also allows e.g. predefining expected IPs before fully expanding a cluster.

E.g. with this PR this configuration passes validation but creates no nodes:

```hcl
# environments/staging/tofu/main.tf:
module "cluster" {
  ...
  compute = {
    gpu = {
      nodes = []
      ip_addresses = {
        mynet = ["192.168.0.14", "192.168.0.15"]
      }
    }
  }
}
```



