### PR TITLE
Add option to install nvidia-fabricmanager

### DIFF
--- a/ansible/roles/cuda/defaults/main.yml
+++ b/ansible/roles/cuda/defaults/main.yml
@@ -20,5 +20,4 @@ cuda_samples_programs:
   - bandwidthTest
 # cuda_devices: # discovered from deviceQuery run
 cuda_persistenced_state: started
-# option whether or not to install nvidia-fabricmanager default false
 cuda_install_nvidiafabricmanger: false


### PR DESCRIPTION
Adds `cuda_install_nvidiafabricmanger` to allow installing NVIDIA Fabric Manager during an image build with `cuda` enabled. Required for functioning GPUs on e.g. DGX H200 nodes.