### PR TITLE
Avoid compute node replacements due to optional user_data

### DIFF
--- a/environments/site/tofu/node_group/nodes.tf
+++ b/environments/site/tofu/node_group/nodes.tf
@@ -134,9 +134,9 @@ resource "openstack_compute_instance_v2" "compute_fixed_image" {
 
   user_data = <<-EOF
     #cloud-config
-    fqdn: ${local.fqdns[each.key]}
+    fqdn: ${local.fqdns[each.key]}%{if var.additional_cloud_config != ""}
 
-    %{if var.additional_cloud_config != ""}
+
     ${templatestring(var.additional_cloud_config, var.additional_cloud_config_vars)}
     %{endif}
   EOF


### PR DESCRIPTION
When support for the OpenTofu variable `additional_cloud_config` was added, newline characters were also added outside of the conditional block. This means compute_fixed_image instances would be scheduled for replacement on the next tofu apply. This breaks slurm controlled rebuilds, as these fixed nodes should not be replaced at this step.

Correct this by moving the newlines to be within the conditional block. The double newline is preserved to avoid breaking systems which are already using both additional_cloud_config and slurm controlled rebuild.