### PR TITLE
Reformat user_data for other nodes

### DIFF
--- a/environments/site/tofu/control.tf
+++ b/environments/site/tofu/control.tf
@@ -105,9 +105,8 @@ resource "openstack_compute_instance_v2" "control" {
       - [LABEL=state, ${var.state_dir}]
       %{if var.home_volume_provisioning != "none"}
       - [LABEL=home, /exports/home]
-      %{endif}
+      %{endif}%{if var.additional_cloud_config != ""}
 
-    %{if var.additional_cloud_config != ""}
     ${templatestring(var.additional_cloud_config, var.additional_cloud_config_vars)}
     %{endif}
   EOF

--- a/environments/site/tofu/node_group/nodes.tf
+++ b/environments/site/tofu/node_group/nodes.tf
@@ -202,9 +202,9 @@ resource "openstack_compute_instance_v2" "compute" {
 
   user_data = <<-EOF
     #cloud-config
-    fqdn: ${local.fqdns[each.key]}
+    fqdn: ${local.fqdns[each.key]}%{if var.additional_cloud_config != ""}
 
-    %{if var.additional_cloud_config != ""}
+
     ${templatestring(var.additional_cloud_config, var.additional_cloud_config_vars)}
     %{endif}
   EOF


### PR DESCRIPTION
PR #757 ("Add option for additional user data") added additional whitespace to userdata, meaning that all nodes would undergo a delete/recreate even if not otherwise required.

PR #847 fixed this for "fixed image" compute nodes (i.e. slurm-controlled-rebuild compute nodes) only.

This PR fixes it for all other nodes; non-"fixed image" compute nodes, login/additional and control nodes.

**NB:** These PRs *only* fix it for appliances deployed before PR #757 (v2.3). For appliances deployed after that, either accepting the delete/recreate or manually modifying the OpenTofu configurations to prevent changes will be required.