### PR TITLE
Fix image-set-properties.sh: hw_disk_bus=virtio

### DIFF
--- a/dev/image-set-properties.sh
+++ b/dev/image-set-properties.sh
@@ -34,8 +34,6 @@ else
     echo setting qcow2 properties
     set -x
     openstack image set \
-    --property hw_scsi_model=virtio-scsi \
-    --property hw_disk_bus=scsi \
-    --property hw_scsi_model=virtio \
+    --property hw_disk_bus=virtio \
     "$image"
 fi


### PR DESCRIPTION
a wrong property was set, preventing launch from qcow2 images