### PR TITLE
Fix TOFU ssh key prompt in OpenOnDemand web shell for IPA hosts

### DIFF
--- a/environments/common/inventory/group_vars/all/openondemand.yml
+++ b/environments/common/inventory/group_vars/all/openondemand.yml
@@ -35,7 +35,7 @@ openondemand_dashboard_links_grafana:
 openondemand_dashboard_links: "{{ openondemand_dashboard_links_grafana if groups['grafana'] | length > 0 }}"
 
 # For FreeIPA-enroled hosts, the shell host must be an IPA-registered host to avoid an ssh key prompt
-# so use do not use localhost:
+# so do not use localhost:
 openondemand_login_host: "{{ inventory_hostname }}"
 
 openondemand_clusters:


### PR DESCRIPTION
The appliance defaults the host to use for the Open Ondemand web shell to `localhost`, because it defaults the `openondemand` group to the `login` group. However for FreeIPA-enroled hosts, ssh key checks are done against an IPA-controlled known hosts file (which does not include localhost) so the [keyscan task](https://github.com/stackhpc/ansible-slurm-appliance/blob/main/ansible/roles/openondemand/tasks/main.yml#L148) is not effective.

However as the IPA-controlled known hosts file does include all IPA hosts, by changing the web shell host to an actual hostname, the user does not have to accept the key on first use.