### PR TITLE
Attempt to fix permissions for trivy scan on main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,8 @@ permissions:
   # To report GitHub Actions status checks
   statuses: write
   id-token: write
+  # upload trivy scan results
+  security-events: write
 
 on:
   push:
@@ -143,6 +145,6 @@ jobs:
     name: Trivy scan image for vulnerabilities
     needs: files_changed
     if: |
-      needs.files_changed.outputs.trivyscan == 'true'
+      needs.files_changed.outputs.trivyscan == 'true' || github.event_name != 'pull_request'
     uses: ./.github/workflows/trivyscan.yml
     secrets: inherit

--- a/.github/workflows/trivyscan.yml
+++ b/.github/workflows/trivyscan.yml
@@ -14,6 +14,8 @@ permissions:
   packages: write
   # To report GitHub Actions status checks
   statuses: write
+  # upload trivy scan results
+  security-events: write
 
 jobs:
   scan:


### PR DESCRIPTION
While the scan works on PRs, we have permissions related failures for the run on the main branch, this attempts to fix that.

More details on what is needed are here:
https://github.com/github/codeql-action/blob/c43362b91a940600cde2ebae39ec7a35ad66bdc0/upload-sarif/action.yml#L23C253-L24C20

Similarly, this moves to always scan the image on main, as a way to double check there are no new blocking CVEs more regularly than just when the image is bumped.