### PR TITLE
Write summary from hpctests pingpong to repo

### DIFF
--- a/ansible/roles/hpctests/tasks/pingpong.yml
+++ b/ansible/roles/hpctests/tasks/pingpong.yml
@@ -88,5 +88,6 @@
   ansible.builtin.copy:
     dest: "{{ _pingpong_local_output | dirname }}/summary.txt"
     content: "{{ hpctests_pingpong_summary }}"
+    mode: "0644"
   delegate_to: localhost
   become: false


### PR DESCRIPTION
Writes the summary description for the hpctests pingpong test (currently printed to stdout only) to the repo. This allows committing it alongside the existing plot and raw results to make reviewing performance drift easier.