### PR TITLE
Update tf s3 backend instructions for better ec2 credential behaviour

### DIFF
--- a/docs/opentofu-remote-state.md
+++ b/docs/opentofu-remote-state.md
@@ -146,7 +146,7 @@ per-checkout configuration is required.
    TOKEN_DATA=$(openstack token issue -f json)
    PROJECT_ID=$(echo "$TOKEN_DATA" | jq -r '.project_id')
    TOKEN_ID=$(echo "$TOKEN_DATA" | jq -r '.id')
-   openstack revoke token $TOKEN_ID
+   openstack token revoke $TOKEN_ID
    
    # Get first creds in current project:
    EC2_CREDS=$(openstack ec2 credentials list -f json | jq -r --arg pid "$PROJECT_ID" '.[] | select(.["Project ID"] == $pid) | @json' | head -n 1)


### PR DESCRIPTION
The current instructions for the s3 OpenTofu backend miss the fact that credentials are per-user, hence hardcoding the access ID into the environment activate script does not work for.

This PR updates these instructions to instead extract the first credentials for the current project, and use those.

Tested at client.