### PR TITLE
Support templating and ansible_ssh_common_args in ansible-ssh

### DIFF
--- a/dev/ansible-ssh
+++ b/dev/ansible-ssh
@@ -49,6 +49,8 @@ if __name__ == "__main__":
     # output looks like e.g.
     # stg-login-0 | SUCCESS => {    "changed": false,    ...
     # one line per host
+    if not output:
+        sys.exit(1)
     result = output.splitlines()[0].split('>', 1)[-1]
     expanded = json.loads(result)['msg']
     # can assume ansible_host exists b/c defined by terraform


### PR DESCRIPTION
Enhances the `dev/ansible-ssh` script to:
- Use `ansible_ssh_common_args` inventory variable
- Support Jinja templating in the inventory variables

This makes it possible to use this script for clusters accessed through a jumphost.