### PR TITLE
alertmanager: support tuning systemd sandboxing

### DIFF
--- a/ansible/roles/alertmanager/defaults/main.yml
+++ b/ansible/roles/alertmanager/defaults/main.yml
@@ -50,3 +50,13 @@ alertmanager_config_default:
   receivers: "{{ alertmanager_receivers }}"
 
 alertmanager_config_extra: {} # top-level only
+
+# Whether to set ProtectHome=true in systemd unit. This option may need to be
+# disabled in some environments, to avoid a "Failed to set up mount
+# namespacing" error when starting alertmanager.
+alertmanager_systemd_protect_home: true
+
+# Whether to set ProtectSystem=strict in systemd unit. This option may need to
+# be disabled in some environments, to avoid a "Failed to set up mount
+# namespacing" error when starting alertmanager.
+alertmanager_systemd_protect_system: true

--- a/ansible/roles/alertmanager/templates/alertmanager.service.j2
+++ b/ansible/roles/alertmanager/templates/alertmanager.service.j2
@@ -38,7 +38,9 @@ LockPersonality=true
 NoNewPrivileges=true
 MemoryDenyWriteExecute=true
 PrivateTmp=true
+{% if alertmanager_systemd_protect_home | bool %}
 ProtectHome=true
+{% endif %}
 ReadWriteDirectories={{ alertmanager_storage_path }}
 RemoveIPC=true
 RestrictSUIDSGID=true
@@ -47,7 +49,9 @@ PrivateUsers=true
 ProtectControlGroups=true
 ProtectKernelModules=true
 ProtectKernelTunables=yes
+{% if alertmanager_systemd_protect_system | bool %}
 ProtectSystem=strict
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
We had to disable some systemd sandboxing options in an environment with NFS shares mounted.