### PR TITLE
alertmanager: Fix Slack integration

### DIFF
--- a/environments/site/inventory/group_vars/all/alertmanager.yml
+++ b/environments/site/inventory/group_vars/all/alertmanager.yml
@@ -3,4 +3,4 @@
 #
 # alertmanager_slack_integration:
 #   channel: '#alerts'
-#   app_creds: "{% raw %}{{ vault_alertmanager_slack_integration_app_creds }}{% endraw %}"
+#   app_creds: "{{ vault_alertmanager_slack_integration_app_creds }}"


### PR DESCRIPTION
The escaping is not necessary ever since cookiecutter was removed.