### PR TITLE
basic_users role: Prevent user changes to skeleton-templated files being lost

### DIFF
--- a/ansible/roles/basic_users/tasks/main.yml
+++ b/ansible/roles/basic_users/tasks/main.yml
@@ -61,6 +61,7 @@
     owner: "{{ item.name }}"
     group: "{{ item.name }}"
     mode: u=rwX,go=
+    force: false # prevents user changes to skeleton being overwritten
   loop: "{{ basic_users_users }}"
   loop_control:
     label: "{{ item.name }}"


### PR DESCRIPTION
Currently if users change e.g. `.bashrc` that change is lost when `basic_users` is rerun