### PR TITLE
Run tofu from anywhere

### DIFF
--- a/cookiecutter/{{cookiecutter.environment}}/activate
+++ b/cookiecutter/{{cookiecutter.environment}}/activate
@@ -18,3 +18,5 @@ echo "Setting PKR_VAR_repo_root to $PKR_VAR_repo_root"
 if [ -f "$APPLIANCES_ENVIRONMENT_ROOT/ansible.cfg" ]; then
    export ANSIBLE_CONFIG=$APPLIANCES_ENVIRONMENT_ROOT/ansible.cfg
 fi
+
+alias tofu="`which tofu` -chdir=$APPLIANCES_ENVIRONMENT_ROOT/tofu"

--- a/environments/.stackhpc/activate
+++ b/environments/.stackhpc/activate
@@ -18,3 +18,5 @@ echo "Setting PKR_VAR_repo_root to $PKR_VAR_repo_root"
 if [ -f "$APPLIANCES_ENVIRONMENT_ROOT/ansible.cfg" ]; then
    export ANSIBLE_CONFIG=$APPLIANCES_ENVIRONMENT_ROOT/ansible.cfg
 fi
+
+alias tofu="`which tofu` -chdir=$APPLIANCES_ENVIRONMENT_ROOT/tofu"


### PR DESCRIPTION
It's a pain the arse to switch to the tofu directory everytime you want to run tofu. This adds an alias which allows you to run tofu from anywhere, respecting the currently activated environment.

This can prevent mistakes such as when a user changes to the tofu directory of a different environment.