### PR TITLE
Add grubby with copy fail mitigations

### DIFF
--- a/ansible/.gitignore
+++ b/ansible/.gitignore
@@ -106,3 +106,5 @@ roles/*
 !roles/mounts/**
 !roles/opkssh/
 !roles/opkssh/**
+!roles/grubby/
+!roles/grubby/**

--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -36,6 +36,14 @@
     - ansible.builtin.import_role:
         name: journald
 
+- hosts: grubby
+  become: true
+  gather_facts: false
+  tags: grubby
+  tasks:
+    - ansible.builtin.include_role:
+        name: grubby
+
 - hosts: resolv_conf
   become: true
   gather_facts: false

--- a/ansible/roles/grubby/defaults/main.yml
+++ b/ansible/roles/grubby/defaults/main.yml
@@ -1,0 +1,7 @@
+grubby_kernel: ALL
+grubby_args_present_default:
+  # CVE-2026-31431 copy.fail mitigation:
+  initcall_blacklist: af_alg_init,algif_hash_init,algif_skcipher_init,algif_aead_init,rng_init
+grubby_args_present_extra: {}
+grubby_args_present: "{{ grubby_args_present_default | combine(grubby_args_present_extra) }}"
+grubby_args_absent: []

--- a/ansible/roles/grubby/tasks/main.yml
+++ b/ansible/roles/grubby/tasks/main.yml
@@ -1,0 +1,33 @@
+# TODO: decide on reboot logic
+# TODO: test idempotency
+#   ok: run, reboot, run, shows no changes
+# TODO: test RL8
+#   ok after reboot both RL8 and RL9 did have the initcall_blacklist in /proc/cmdline
+
+- name: Get kernel config before changes
+  ansible.builtin.command:
+    cmd: grubby --info=DEFAULT
+  register: _grubby_info_pre
+
+- name: Set commandline via grubby
+  ansible.builtin.command: # TODO: remove echo!
+    cmd: >-
+      grubby
+      --update-kernel={{ grubby_kernel }}
+      {% if grubby_args_present %}--args=\"{{ grubby_args_present.items() | map('join', '=') | join(' ') }}\"{% endif %}
+      {% if grubby_args_absent %}--remove-args=\"{{ grubby_remove_args | join(' ') }}\"{% endif %}
+
+- name: Get kernel config after changes
+  ansible.builtin.command:
+    cmd: grubby --info=DEFAULT
+  register: _grubby_info_post
+
+- name: Check for changes # TODO: decide if we need this
+  ansible.builtin.debug:
+    msg: |
+      same? {{ _grubby_info_pre.stdout == _grubby_info_post.stdout }}
+
+      diff:
+      {{ _grubby_info_pre.stdout | ansible.utils.fact_diff(_grubby_info_post.stdout) }}
+
+- meta: end_here # TODO: remove

--- a/environments/common/inventory/groups
+++ b/environments/common/inventory/groups
@@ -244,3 +244,6 @@ doca
 
 [opkssh]
 # Hosts to run opkssh to allow SSH via OIDC
+
+[grubby]
+# Hosts to modify kernel command line on

--- a/environments/site/inventory/groups
+++ b/environments/site/inventory/groups
@@ -216,3 +216,7 @@ compute
 
 [opkssh]
 # Hosts to run opkssh to allow SSH via OIDC
+
+[grubby:children]
+# Hosts to modify kernel command line on
+fatimage


### PR DESCRIPTION
Adds `grubby` role to modify kernel command line, with defaults to mitigate CVE-2026-31431 ("Copy Fail") via disabling AF_ALG functions built into the kernel. Role is enabled by default for `fatimage` builds.

TODO: decide if we actually need any reboot logic. Not very obvious what right thing is here TBH:
- Don't need to reboot a build in this case, do we ever??
- bootstrap.yml contains some logic to reboot on e.g. package changes, so could hook that if we DO ever need a restart, rather than doing x2.
- Could say you never want to reboot a running cluster via site.
- Could say you should give users the option, which when set (not by default) will do a reboot (probably via existing bootstrap reboot) IF there's been a change. This is probably the best get-out.
- Could say you should warn users if there's been a change. Very hard to make obvious. There's no way to force "needs-restarting" return true, apparently.
TODO: tidy up dev comments and convert test notes to comments here
TODO: actually build image

