### PR TITLE
Fix mounts role failing to create directories

### DIFF
--- a/ansible/roles/mounts/tasks/main.yml
+++ b/ansible/roles/mounts/tasks/main.yml
@@ -3,6 +3,7 @@
     path: "{{ item.value.path }}"
     state: directory
   loop: "{{ mounts | dict2items }}"
+  when: item.value.enabled | default(true)
 
 - name: Ensure tmp.mount mask status is correct
   # RL8-specific fix; otherwise rootfs comes up read-only after a reboot!

--- a/ansible/roles/mounts/tasks/main.yml
+++ b/ansible/roles/mounts/tasks/main.yml
@@ -2,6 +2,9 @@
   ansible.builtin.file:
     path: "{{ item.value.path }}"
     state: directory
+    owner: root
+    group: root
+    mode: '0755'
   loop: "{{ mounts | dict2items }}"
   when: item.value.enabled | default(true)
 

--- a/ansible/roles/mounts/tasks/main.yml
+++ b/ansible/roles/mounts/tasks/main.yml
@@ -1,6 +1,7 @@
 - name: Ensure mount directories exist
   ansible.builtin.file:
     path: "{{ item.value.path }}"
+    state: directory
   loop: "{{ mounts | dict2items }}"
 
 - name: Ensure tmp.mount mask status is correct


### PR DESCRIPTION
Without specifying "state: directory", the file module will fail when the directory is absent:

```
May 07 12:32:33 stagingcompute000 ansible-init[2275]: TASK [mounts : Ensure mount directories exist] *********************************
May 07 12:32:34 stagingcompute000 ansible-init[2275]: failed: [127.0.0.1] (item={'key': 'namespace-tmpfs', 'value': {'enabled': True, 'fstype': 'tmpfs', 'opts': 'mode=1777,strictatime,nosuid,nodev,size=10%,nr_inodes=1m', 'path': '/namespace-tmpfs', 'src': 'tmpfs', 'state': 'mounted'}}) => {"ansible_loop_var": "item", "changed": false, "item": {"key": "namespace-tmpfs", "value": {"enabled": true, "fstype": "tmpfs", "opts": "mode=1777,strictatime,nosuid,nodev,size=10%,nr_inodes=1m", "path": "/namespace-tmpfs", "src": "tmpfs", "state": "mounted"}}, "msg": "file (/namespace-tmpfs) is absent, cannot continue", "path": "/namespace-tmpfs", "state": "absent"}
```