### PR TITLE
Fix pulp sync on RL8

### DIFF
--- a/ansible/adhoc/sync-pulp.yml
+++ b/ansible/adhoc/sync-pulp.yml
@@ -4,6 +4,3 @@
     - ansible.builtin.include_role:
         name: pulp_site
         tasks_from: sync.yml
-      vars:
-        # default distribution to *latest* specified for baseos repo:
-        pulp_site_target_distribution_version: "{{ dnf_repos_repos['baseos'].keys() | map('float') | sort | last }}"

--- a/ansible/fatimage.yml
+++ b/ansible/fatimage.yml
@@ -32,12 +32,15 @@
 
 - name: Sync pulp repos with upstream
   hosts: pulp_site
+  gather_facts: true
   tasks:
     - ansible.builtin.include_role:
         name: pulp_site
         tasks_from: sync.yml
         apply:
           delegate_to: localhost
+      vars:
+        pulp_site_target_distribution_version: "{{ hostvars[groups['pulp_site'][0]]['ansible_facts']['distribution_version'] }}"
       when: appliances_mode != 'configure'
 
 - import_playbook: bootstrap.yml

--- a/ansible/roles/pulp_site/README.md
+++ b/ansible/roles/pulp_site/README.md
@@ -20,9 +20,7 @@ tested as the target VM for deploying Pulp.
 - `pulp_site_upstream_password`: Required str. Password for upstream Ark Pulp server.
 - `pulp_site_upstream_content_url`: Optional str. Content URL of upstream Ark Pulp. Defaults to `https://ark.stackhpc.com/pulp/content`.
 - `pulp_site_install_dir`: Optional str. Directory on Pulp host to install config and persistent state to be mounted into Pulp container. Defaults to `/home/rocky/pulp`.
-- `pulp_site_target_facts`: Optional str. The `ansible_facts` of a host which will be pulling from your Pulp server, allowing the role to auto-discover the necessary repos to pull.
-  defaults to `{{ hostvars[groups['pulp'][0]]['ansible_facts'] }}`.
-- `pulp_site_target_distribution_version`: Optional str. The Rocky Linux minor release to sync repos from Ark for. Defaults to `{{ pulp_site_target_facts['distribution_version'] }}`.
+- `pulp_site_target_distribution_version`: Required str. The Rocky Linux minor release to sync repos from Ark for. Defaulted to latest supported distro by `environments/common/inventory/group_vars/all/pulp.yml`.
 - `pulp_site_rpm_repo_defaults`: Optional dict. Contains key-value pairs for fields which are common to all repository definition in `pulp_site_rpm_repos`. Includes values for `remote_username`,
   `remote_password` and `policy` by default.
 - `pulp_site_rpm_repos`: Optional list of dicts. List of repository definitions in format required by the `stackhpc.pulp.pulp_repository`. Defaults to modified versions of repos defined in

--- a/ansible/roles/pulp_site/defaults/main.yml
+++ b/ansible/roles/pulp_site/defaults/main.yml
@@ -5,11 +5,10 @@ pulp_site_password: "{{ vault_pulp_admin_password }}"
 # See environments/common/inventory/groups_vars/all/pulp.yml
 # pulp_site_upstream_username:
 # pulp_site_upstream_password:
+# pulp_site_target_distribution_version:
 pulp_site_upstream_content_url: https://ark.stackhpc.com/pulp/content
 pulp_site_install_dir: '/home/rocky/pulp'
 _pulp_site_selinux_suffix: "{{ ':Z' if ansible_selinux.status == 'enabled' else '' }}"
-pulp_site_target_facts: "{{ hostvars[groups['pulp'][0]]['ansible_facts'] }}"
-pulp_site_target_distribution_version: "{{ pulp_site_target_facts['distribution_version'] }}" # TODO: how to set automatically?
 
 pulp_site_rpm_repo_defaults:
   remote_username: "{{ pulp_site_upstream_username }}"

--- a/ansible/roles/pulp_site/filter_plugins/pulp-list-filters.py
+++ b/ansible/roles/pulp_site/filter_plugins/pulp-list-filters.py
@@ -27,10 +27,7 @@ class FilterModule(object):
             elif target_distro_ver_major in dnf_repos[repokey]:
                 selected_ver = target_distro_ver_major
             else:
-                raise ValueError(
-                    # pylint: disable-next=line-too-long
-                    f"No key matching {target_distro_ver_major} or {target_distro_ver} found in f{repokey}"
-                )
+                continue  # e.g. epel-cisco-openh264 only relevant for RL9
             repo_data = dnf_repos[repokey][selected_ver]
             repo_data["pulp_repo_name"] = (
                 f"{repokey}-{selected_ver}-{dnf_repos[repokey][selected_ver]['pulp_timestamp']}"

--- a/environments/common/inventory/group_vars/all/pulp.yml
+++ b/environments/common/inventory/group_vars/all/pulp.yml
@@ -1,5 +1,7 @@
 ---
 pulp_site_port: 8080
+# default to latest distro defined in our environments/common/inventory/group_vars/all/dnf_repo_timestamps.yml:
+pulp_site_target_distribution_version: "{{ dnf_repos_repos['baseos'].keys() | community.general.version_sort | last }}"
 
 # If using Ark directly (no local Pulp server), override the following with Ark creds
 


### PR DESCRIPTION
Fixes a number of issues with pulp sync:
- `pulp_site_target_distribution_version` could not be overridden when using the ansible/adhoc/sync-pulp.yml playbook (closes #779)
- The existing templating for `pulp_site_target_distribution_version` in ansible/adhoc/sync-pulp.yml was incorrect for versions which do not sort as floats (e.g. 8.10)
- Logic in `pulp_site` role for constructing repo lists incorrectly assumed that all repo keys are present for every supported distribution

Does not need CI except linting, is not checked by that.