### PR TITLE
Fix no sssd_packages installed if not sssd_install_ldap

### DIFF
--- a/ansible/roles/sssd/tasks/install.yml
+++ b/ansible/roles/sssd/tasks/install.yml
@@ -1,7 +1,7 @@
 ---
 - name: Ensure sssd packages are installed
   ansible.builtin.dnf:
-    name: "{{ sssd_packages + sssd_ldap_packages if (sssd_install_ldap | bool) else [] }}"
+    name: "{{ sssd_packages + (sssd_ldap_packages if (sssd_install_ldap | bool) else []) }}"
 
 - name: Control if sssd should start on boot
   # Needs to be done here to prevent starting after image build, is enabled by default


### PR DESCRIPTION
Precedence rules are tricky, resulting in an empty list of package (the `else []` clause) if not `sssd_install_ldap`.

```
#  ansible -m debug -a msg="{{ ['a'] + ['b'] if True else []}}" localhost
==> "msg": ["a", "b"]

#  ansible -m debug -a msg="{{ ['a'] + ['b'] if False else []}}" localhost
==> "msg": []
```
