### PR TITLE
Add dirtyfrag mitigation to images

### DIFF
--- a/ansible/fatimage.yml
+++ b/ansible/fatimage.yml
@@ -30,6 +30,8 @@
 
 - ansible.builtin.import_playbook: validate-galaxy.yml
 
+- ansible.builtin.import_playbook: mitigations.yml
+
 - name: Sync pulp repos with upstream
   hosts: pulp_site
   gather_facts: true

--- a/ansible/mitigations.yml
+++ b/ansible/mitigations.yml
@@ -1,5 +1,5 @@
 - name: Apply dirtyfrag mitigation
-  hosts: mitgate_dirtyfrag
+  hosts: mitigate_dirtyfrag
   gather_facts: false
   become: true
   tasks:

--- a/ansible/mitigations.yml
+++ b/ansible/mitigations.yml
@@ -1,0 +1,25 @@
+- name: Apply dirtyfrag mitigation
+  hosts: mitgate_dirtyfrag
+  gather_facts: false
+  become: true
+  tasks:
+    - name: Prevent modules loading
+      ansible.builtin.copy:
+        dest: /etc/modprobe.d/dirtyfrag.conf
+        owner: root
+        group: root
+        mode: u=rw,go=r
+        content: |
+          install esp4 /bin/false
+          install esp6 /bin/false
+          install rxrpc /bin/false
+    # below probably is not needed but is safer
+    - name: Unload modules
+      ansible.builtin.command:
+        cmd: rmmod esp4 esp6 rxrpc
+      failed_when: false
+      changed_when: true
+    - name: Clear page cache
+      ansible.builtin.command:
+        cmd: echo 3 > /proc/sys/vm/drop_caches
+      changed_when: true

--- a/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
+++ b/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
@@ -1,6 +1,6 @@
 {
   "cluster_image": {
-    "RL8": "openhpc-RL9-260508-0933-8557fcea",
-    "RL9": "openhpc-RL8-260508-1009-8557fcea"
+    "RL8": "openhpc-RL8-260508-1119-0374764b",
+    "RL9": "openhpc-RL9-260508-1119-0374764b"
   }
 }

--- a/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
+++ b/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
@@ -1,6 +1,6 @@
 {
   "cluster_image": {
-    "RL8": "openhpc-RL8-260507-1911-f923a963",
-    "RL9": "openhpc-RL9-260507-1911-f923a963"
+    "RL8": "openhpc-RL9-260508-0933-8557fcea",
+    "RL9": "openhpc-RL8-260508-1009-8557fcea"
   }
 }

--- a/environments/common/inventory/groups
+++ b/environments/common/inventory/groups
@@ -244,3 +244,6 @@ doca
 
 [opkssh]
 # Hosts to run opkssh to allow SSH via OIDC
+
+## Vulnerability mitigation groups
+[mitgate_dirtyfrag]

--- a/environments/common/inventory/groups
+++ b/environments/common/inventory/groups
@@ -246,4 +246,4 @@ doca
 # Hosts to run opkssh to allow SSH via OIDC
 
 ## Vulnerability mitigation groups
-[mitgate_dirtyfrag]
+[mitigate_dirtyfrag]

--- a/environments/site/inventory/groups
+++ b/environments/site/inventory/groups
@@ -216,3 +216,7 @@ compute
 
 [opkssh]
 # Hosts to run opkssh to allow SSH via OIDC
+
+## Vulnerability mitigation groups
+[mitgate_dirtyfrag:children]
+builder

--- a/environments/site/inventory/groups
+++ b/environments/site/inventory/groups
@@ -218,5 +218,5 @@ compute
 # Hosts to run opkssh to allow SSH via OIDC
 
 ## Vulnerability mitigation groups
-[mitgate_dirtyfrag:children]
+[mitigate_dirtyfrag:children]
 builder


### PR DESCRIPTION
Disables loading of `esp4`, `esp6` and `rxrpc` kernel modules to mitigate [dirtyfrag](https://github.com/V4bel/dirtyfrag) and [Copy Fail 2: Electric Boogaloo](https://github.com/0xdeadbeefnetwork/Copy_Fail2-Electric_Boogaloo).

The mitigation is configured in all image builds by default.
