### PR TITLE
Fix mounts role changes permissions on mounted contents

### DIFF
--- a/ansible/roles/mounts/tasks/main.yml
+++ b/ansible/roles/mounts/tasks/main.yml
@@ -1,12 +1,23 @@
+---
+
+- name: Check mount directories
+  ansible.builtin.stat:
+    path: "{{ item.path }}"
+  register: _mounts_mountpoints
+  loop: "{{ mounts.values() }}"
+  when: item.enabled | default(true)
+
 - name: Ensure mount directories exist
   ansible.builtin.file:
-    path: "{{ item.value.path }}"
+    path: "{{ stat_result.item.path }}"
     state: directory
     owner: root
     group: root
     mode: '0755'
-  loop: "{{ mounts | dict2items }}"
-  when: item.value.enabled | default(true)
+  loop: "{{ _mounts_mountpoints.results | default([]) }}"
+  loop_control:
+    loop_var: stat_result
+  when: (stat_result.stat | default(false)) and not stat_result.stat.exists
 
 - name: Ensure tmp.mount mask status is correct
   # RL8-specific fix; otherwise rootfs comes up read-only after a reboot!

--- a/ansible/roles/mounts/tasks/main.yml
+++ b/ansible/roles/mounts/tasks/main.yml
@@ -17,7 +17,9 @@
   loop: "{{ _mounts_mountpoints.results | default([]) }}"
   loop_control:
     loop_var: stat_result
-  when: (stat_result.stat | default(false)) and not stat_result.stat.exists
+  # Only run when mountpoint is missing, to avoid resetting owner/mode on mounted directories
+  # Also has to cope with .stat missing when enabled: false
+  when: not (stat_results.stat.exists | default(true))
 
 - name: Ensure tmp.mount mask status is correct
   # RL8-specific fix; otherwise rootfs comes up read-only after a reboot!

--- a/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
+++ b/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
@@ -1,6 +1,6 @@
 {
   "cluster_image": {
-    "RL8": "openhpc-RL8-260508-1119-0374764b",
-    "RL9": "openhpc-RL9-260508-1119-0374764b"
+    "RL8": "openhpc-RL8-260512-1609-e5b0ee4d",
+    "RL9": "openhpc-RL9-260513-0815-e5b0ee4d"
   }
 }


### PR DESCRIPTION
Only create the mountpoint if it doesn't exist, 
to avoid changing permissions of the mounted content with the file module.