### PR TITLE
Fix logic in build for desktop and lustre installs

### DIFF
--- a/ansible/fatimage.yml
+++ b/ansible/fatimage.yml
@@ -152,7 +152,7 @@
       ansible.builtin.include_role:
         name: openondemand
         tasks_from: vnc_compute.yml
-      when: "'openondemand_desktop' or 'openondemand_matlab' in group_names"
+      when: "'openondemand_desktop' in group_names or 'openondemand_matlab' in group_names"
 
     - name: Open OnDemand Jupyter node
       ansible.builtin.include_role:

--- a/ansible/roles/lustre/tasks/install.yml
+++ b/ansible/roles/lustre/tasks/install.yml
@@ -34,7 +34,8 @@
 
 - name: Check rpms found
   ansible.builtin.assert:
-    that: _lustre_find_rpms.files | length
+    that:
+      - _lustre_find_rpms.matched > 0
     fail_msg: "No lustre repos found with lustre_rpm_globs = {{ lustre_rpm_globs }}"
 
 - name: Install lustre rpms

--- a/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
+++ b/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
@@ -1,6 +1,6 @@
 {
   "cluster_image": {
-    "RL8": "openhpc-RL8-260513-1021-a12d2870",
-    "RL9": "openhpc-RL9-260513-1021-a12d2870"
+    "RL8": "openhpc-RL8-260514-1440-782c2f57",
+    "RL9": "openhpc-RL9-260514-1440-782c2f57"
   }
 }


### PR DESCRIPTION
Adopted from  #949.

- Fixes error logic in fatimage.yml for vnc desktop installation - so requires build
- Fixes logic in lustre installation: ansible-core >= 2.15 requires conditionals to explicitly evaluate to a boolean so lustre builds fail with "Conditionals must have a boolean result".