### PR TITLE
Fix image build post-filesystems hook

### DIFF
--- a/ansible/fatimage.yml
+++ b/ansible/fatimage.yml
@@ -101,7 +101,7 @@
 
 - name: Run post-filesystems.yml hook
   vars:
-    appliances_environment_root: "{{ ansible_inventory_sources | last | dirname }}"
+    appliances_environment_root: "{{ lookup('env', 'APPLIANCES_ENVIRONMENT_ROOT') }}"
     hook_path: "{{ appliances_environment_root }}/hooks/post-filesystems.yml"
   ansible.builtin.import_playbook: "{{ hook_path if hook_path | exists else 'noop.yml' }}"
   when: hook_path | exists


### PR DESCRIPTION
Fixes a bug in #968 which meant the the post-filesystems hook did not run on build. The way this hook is done now is the way the other hooks are triggered in fatimage.yml