### PR TITLE
Use all ansible connection properties for dev/ansible-ssh

### DIFF
--- a/dev/ansible-ssh
+++ b/dev/ansible-ssh
@@ -38,9 +38,7 @@ if __name__ == "__main__":
     for line in output.splitlines():
         match = re.match(r".*SSH: EXEC (.*) '/bin/sh", line)
         if match is not None:
-            if len(match.groups()) != 1:
-                sys.exit("ERROR: Could not extract SSH command from output")
-            ssh_cmd = match.groups()[0]
+            ssh_cmd = match.group(1)
             # strip out verbosity flags
             ssh_cmd = re.sub(r"\s+-v+\b", "", ssh_cmd)
             # strip out our timeout arg

--- a/dev/ansible-ssh
+++ b/dev/ansible-ssh
@@ -1,32 +1,22 @@
 #!/usr/bin/env python3
 """
-SSH to a cluster host using connection properties from Ansible inventory.
+SSH to a cluster host using Ansible connection properties from inventory,
+configuration, environment vars etc.
 
 Usage:
-   ansible-ssh [-n] PATTERN
+   ansible-ssh PATTERN
 
 where PATTERN can be any of:
     - host e.g. mycluster-login-0
     - group e.g. login
     - group[index] e.g. compute[0]
-options:
-    -n      Disable strict host key checking and do not store accepted keys
 """
 
-import json
+import re
 import os
 import shlex
 import subprocess
 import sys
-
-NO_HOSTKEY_CHECK_OPTS = [
-    "-o",
-    "StrictHostKeyChecking=no",
-    "-o",
-    "GlobalKnownHostsFile=/dev/null",
-    "-o",
-    "UserKnownHostsFile=/dev/null",
-]
 
 if __name__ == "__main__":
     no_known_hosts = "-n" in sys.argv
@@ -35,35 +25,30 @@ if __name__ == "__main__":
         sys.exit(-1)
 
     pattern = sys.argv[-1]
-
-    template_str = (
-        "ssh "
-        "{% if ansible_ssh_port | default(false) %}-p {{ ansible_ssh_port }} {% endif %}"
-        "{% if ansible_ssh_private_key_file | default(false) %} -i {{ ansible_ssh_private_key_file }} {% endif %}"
-        "{{ ansible_ssh_common_args | default('') }} "
-        "{{ ansible_user }}@{{ ansible_host }}"
-    )
-    module_args = json.dumps({"msg": template_str})
-    ansible_cmd = ["ansible", pattern, "-o", "-m", "debug", "-a", module_args]
+    ansible_cmd = ["ansible", pattern, "-a", "hostname", "-vvvv", "--timeout", "1"]
     try:
         output = subprocess.check_output(ansible_cmd, text=True)
     except subprocess.CalledProcessError:
         msg = "[ERROR]: ansible exited in error"
         print(msg, file=sys.stderr)
         sys.exit(-1)
-    # output looks like e.g.
-    # stg-login-0 | SUCCESS => {    "changed": false,    ...
-    # one line per host
     if not output:
         sys.exit(1)
-    result = output.splitlines()[0].split(">", 1)[-1]
-    expanded = json.loads(result)["msg"]
-    # can assume ansible_host exists b/c defined by terraform
-    # can assume ansible_user exists b/c defined in common inventory
-
-    cmd = shlex.split(expanded)
-    if no_known_hosts:
-        cmd = cmd[0:1] + NO_HOSTKEY_CHECK_OPTS + cmd[1:]
+    ssh_cmd = None
+    for line in output.splitlines():
+        match = re.match(r".*SSH: EXEC (.*) '/bin/sh", line)
+        if match is not None:
+            if len(match.groups()) != 1:
+                sys.exit("ERROR: Could not extract SSH command from output")
+            ssh_cmd = match.groups()[0]
+            # strip out verbosity flags
+            ssh_cmd = re.sub(r"\s+-v+\b", "", ssh_cmd)
+            # strip out our timeout arg
+            ssh_cmd = re.sub(r"-o ConnectTimeout=1", "", ssh_cmd)
+            continue
+    if ssh_cmd is None:
+        sys.exit("ERROR: Did not find SSH command in output")
+    cmd = shlex.split(ssh_cmd)
 
     print(f"[INFO]: Running: {subprocess.list2cmdline(cmd)}")
     os.execvp(cmd[0], cmd)

--- a/dev/ansible-ssh
+++ b/dev/ansible-ssh
@@ -45,7 +45,7 @@ if __name__ == "__main__":
             ssh_cmd = re.sub(r"\s+-v+\b", "", ssh_cmd)
             # strip out our timeout arg
             ssh_cmd = re.sub(r"-o ConnectTimeout=1", "", ssh_cmd)
-            continue
+            break
     if ssh_cmd is None:
         sys.exit("ERROR: Did not find SSH command in output")
     cmd = shlex.split(ssh_cmd)


### PR DESCRIPTION
Adds support for environment variables and ansible configuration to the `dev/ansible-ssh` tool. Makes dev more convenient since #974 uses environment variables for  StackHPC CI SSH configuration.

Tool is not tested in CI so can ignore everything except linting.