### PR TITLE
Update OS packages for RockyLinux 8.10 and 9.7

### DIFF
--- a/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
+++ b/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
@@ -1,6 +1,6 @@
 {
   "cluster_image": {
-    "RL8": "openhpc-RL8-260515-1509-ce6c64e9",
-    "RL9": "openhpc-RL9-260515-1436-ce6c64e9"
+    "RL8": "openhpc-RL8-260603-0842-b38bb57d",
+    "RL9": "openhpc-RL9-260603-0842-b38bb57d"
   }
 }

--- a/environments/common/inventory/group_vars/all/dnf_repo_timestamps.yml
+++ b/environments/common/inventory/group_vars/all/dnf_repo_timestamps.yml
@@ -47,7 +47,7 @@ dnf_repos_default:
   appstream:
     '8.10':
       pulp_path: rocky/8.10/AppStream/x86_64/os
-      pulp_timestamp: 20260506T214027
+      pulp_timestamp: 20260531T214327
       repo_file: Rocky-AppStream
     '9.4':
       pulp_path: rocky/9.4/AppStream/x86_64/os
@@ -63,12 +63,12 @@ dnf_repos_default:
       repo_file: rocky
     '9.7':
       pulp_path: rocky/9.7/AppStream/x86_64/os
-      pulp_timestamp: 20260506T215314
+      pulp_timestamp: 20260520T215442
       repo_file: rocky
   appstream-source:
     '8.10':
       pulp_path: rocky/8.10/AppStream/source/tree
-      pulp_timestamp: 20260506T212931
+      pulp_timestamp: 20260529T214741
       repo_file: Rocky-Sources
     '9.6':
       pulp_path: rocky/9.6/AppStream/source/tree
@@ -76,12 +76,12 @@ dnf_repos_default:
       repo_file: rocky
     '9.7':
       pulp_path: rocky/9.7/AppStream/source/tree
-      pulp_timestamp: 20260506T220234
+      pulp_timestamp: 20260519T215441
       repo_file: rocky
   baseos:
     '8.10':
       pulp_path: rocky/8.10/BaseOS/x86_64/os
-      pulp_timestamp: 20260507T103157
+      pulp_timestamp: 20260531T214327
       repo_file: Rocky-BaseOS
     '9.4':
       pulp_path: rocky/9.4/BaseOS/x86_64/os
@@ -97,12 +97,12 @@ dnf_repos_default:
       repo_file: rocky
     '9.7':
       pulp_path: rocky/9.7/BaseOS/x86_64/os
-      pulp_timestamp: 20260506T222838
+      pulp_timestamp: 20260520T223700
       repo_file: rocky
   baseos-source:
     '8.10':
       pulp_path: rocky/8.10/BaseOS/source/tree
-      pulp_timestamp: 20260506T212931
+      pulp_timestamp: 20260531T212824
       repo_file: Rocky-Sources
     '9.6':
       pulp_path: rocky/9.6/BaseOS/source/tree
@@ -110,7 +110,7 @@ dnf_repos_default:
       repo_file: rocky
     '9.7':
       pulp_path: rocky/9.7/BaseOS/source/tree
-      pulp_timestamp: 20260503T221514
+      pulp_timestamp: 20260519T215441
       repo_file: rocky
   cernvmfs_cfg:
     '8':
@@ -142,7 +142,7 @@ dnf_repos_default:
   crb:
     '8.10':
       pulp_path: rocky/8.10/PowerTools/x86_64/os
-      pulp_timestamp: 20260506T214027
+      pulp_timestamp: 20260531T214327
       repo_file: Rocky-PowerTools
       repo_name: powertools
     '9.4':
@@ -159,12 +159,12 @@ dnf_repos_default:
       repo_file: rocky
     '9.7':
       pulp_path: rocky/9.7/CRB/x86_64/os
-      pulp_timestamp: 20260506T215314
+      pulp_timestamp: 20260519T212648
       repo_file: rocky
   crb-source:
     '8.10':
       pulp_path: rocky/8.10/PowerTools/source/tree
-      pulp_timestamp: 20260427T210741
+      pulp_timestamp: 20260514T213644
       repo_file: Rocky-Sources
       repo_name: powertools-source
     '9.6':
@@ -178,11 +178,11 @@ dnf_repos_default:
   epel:
     '8':
       pulp_path: epel/8/Everything/x86_64
-      pulp_timestamp: 20260506T215737
+      pulp_timestamp: 20260602T004711
       repo_file: epel
     '9':
       pulp_path: epel/9/Everything/x86_64
-      pulp_timestamp: 20260506T215737
+      pulp_timestamp: 20260602T004711
       repo_file: epel
   epel-cisco-openh264:
     '9':
@@ -192,11 +192,11 @@ dnf_repos_default:
   epel-source:
     '8':
       pulp_path: epel/8/Everything/source/tree
-      pulp_timestamp: 20260503T205633
+      pulp_timestamp: 20260602T004711
       repo_file: epel
     '9':
       pulp_path: epel/9/Everything/source/tree
-      pulp_timestamp: 20260506T215737
+      pulp_timestamp: 20260602T004711
       repo_file: epel
   extras:
     '8.10':
@@ -235,11 +235,11 @@ dnf_repos_default:
   grafana:
     '8':
       pulp_path: grafana/oss/rpm
-      pulp_timestamp: 20260506T205914
+      pulp_timestamp: 20260529T211032
       repo_file: grafana
     '9':
       pulp_path: grafana/oss/rpm
-      pulp_timestamp: 20260506T205914
+      pulp_timestamp: 20260529T211032
       repo_file: grafana
   ondemand-web:
     '8':


### PR DESCRIPTION
Update OS packages to latest Ark snapshots for both RockyLinux 8 and 9. This will be the final RockyLinux 9.7 update.